### PR TITLE
9 decimal point limitation

### DIFF
--- a/Tests/Converter.Temperature.Integration.Tests/DoubleTests/ToCelsiusDoubleTests.cs
+++ b/Tests/Converter.Temperature.Integration.Tests/DoubleTests/ToCelsiusDoubleTests.cs
@@ -293,6 +293,58 @@
             result.Should().Be(expected);
         }
 
+        [Theory]
+        [InlineData(0d, -273.15d, -1)]
+        [InlineData(50d, -245.3722222222222d, -1)]
+        [InlineData(100d, -217.59444444444446d, -1)]
+        [InlineData(500d, 4.627777777777769d, -1)]
+        [InlineData(1000d, 282.40555555555557d, -1)]
+        [InlineData(0d, -273d, 0)]
+        [InlineData(50d, -245d, 0)]
+        [InlineData(100d, -218d, 0)]
+        [InlineData(500d, 5d, 0)]
+        [InlineData(1000d, 282d, 0)]
+        [InlineData(0d, -273.2d, 1)]
+        [InlineData(50d, -245.37d, 2)]
+        [InlineData(100d, -217.6d, 1)]
+        [InlineData(500d, 4.62777777777777d, 14)]
+        [InlineData(1000d, 282.41d, 2)]
+        public void Test_double_extension_with_parameter_from_rankine_and_to_celsius_returns_correct_double_value(double value, double expected, int fractionalCount)
+        {
+            // Arrange.
+            // Act.
+            var result = value.FromRankine().ToCelsius(fractionalCount);
+
+            // Assert.
+            result.Should().Be(expected);
+        }
+
+        [Theory]
+        [InlineData(0d, -273.15d, -1)]
+        [InlineData(50d, -245.3722222222222d, -1)]
+        [InlineData(100d, -217.59444444444446d, -1)]
+        [InlineData(500d, 4.627777777777769d, -1)]
+        [InlineData(1000d, 282.40555555555557d, -1)]
+        [InlineData(0d, -273d, 0)]
+        [InlineData(50d, -245d, 0)]
+        [InlineData(100d, -218d, 0)]
+        [InlineData(500d, 5d, 0)]
+        [InlineData(1000d, 282d, 0)]
+        [InlineData(0d, -273.2d, 1)]
+        [InlineData(50d, -245.37d, 2)]
+        [InlineData(100d, -217.6d, 1)]
+        [InlineData(500d, 4.62777777777777d, 14)]
+        [InlineData(1000d, 282.41d, 2)]
+        public void Test_double_extension_generic_with_parameter_from_rankine_and_to_celsius_returns_correct_double_value(double value, double expected, int fractionalCount)
+        {
+            // Arrange.
+            // Act.
+            var result = value.From<Rankine>().To<Celsius>(fractionalCount);
+
+            // Assert.
+            result.Should().Be(expected);
+        }
+
         #endregion From Rankine
     }
 }

--- a/Tests/Converter.Temperature.Integration.Tests/DoubleTests/ToFahrenheitDoubleTests.cs
+++ b/Tests/Converter.Temperature.Integration.Tests/DoubleTests/ToFahrenheitDoubleTests.cs
@@ -65,6 +65,46 @@
             result.Should().Be(expected);
         }
 
+        [Theory]
+        [InlineData(-152436784.334563d, -274386179.8022134d, -1)]
+        [InlineData(0.0d, 32.0d, -1)]
+        [InlineData(26431662.73648262d, 47577024.925668716d, -1)]
+        [InlineData(-152436784.334563d, -274386180d, 0)]
+        [InlineData(0.0d, 32d, 0)]
+        [InlineData(26431662.73648262d, 47577025d, 0)]
+        [InlineData(-152436784.334563d, -274386179.802d, 3)]
+        [InlineData(0.0d, 32.0d, 1)]
+        [InlineData(26431662.73648262d, 47577024.92567d, 5)]
+        public void Test_double_extension_with_parameter_from_celsius_and_to_fahrenheit_returns_correct_double_value(double input, double expected, int fractionalCount)
+        {
+            // Arrange.
+            // Act.
+            var result = input.FromCelsius().ToFahrenheit(fractionalCount);
+
+            // Assert.
+            result.Should().Be(expected);
+        }
+
+        [Theory]
+        [InlineData(-152436784.334563d, -274386179.8022134d, -1)]
+        [InlineData(0.0d, 32.0d, -1)]
+        [InlineData(26431662.73648262d, 47577024.925668716d, -1)]
+        [InlineData(-152436784.334563d, -274386180d, 0)]
+        [InlineData(0.0d, 32d, 0)]
+        [InlineData(26431662.73648262d, 47577025d, 0)]
+        [InlineData(-152436784.334563d, -274386179.802d, 3)]
+        [InlineData(0.0d, 32.0d, 1)]
+        [InlineData(26431662.73648262d, 47577024.92567d, 5)]
+        public void Test_double_extension_generic_with_parameter_from_celsius_and_to_fahrenheit_returns_correct_double_value(double input, double expected, int fractionalCount)
+        {
+            // Arrange.
+            // Act.
+            var result = input.From<Celsius>().To<Fahrenheit>(fractionalCount);
+
+            // Assert.
+            result.Should().Be(expected);
+        }
+
         #endregion From Celsius
 
         #region From Fahrenheit
@@ -224,6 +264,64 @@
             // Arrange.
             // Act.
             var result = value.From<Rankine>().To<Fahrenheit>();
+
+            // Assert.
+            result.Should().Be(expected);
+        }
+
+        [Theory]
+        [InlineData(-1000d, -1459.67d, -1)]
+        [InlineData(0d, -459.67d, -1)]
+        [InlineData(50d, -409.67d, -1)]
+        [InlineData(100d, -359.67d, -1)]
+        [InlineData(500d, 40.329999999999984d, -1)]
+        [InlineData(1000d, 540.3299999999999d, -1)]
+        [InlineData(-1000d, -1460d, 0)]
+        [InlineData(0d, -460d, 0)]
+        [InlineData(50d, -410d, 0)]
+        [InlineData(100d, -360d, 0)]
+        [InlineData(500d, 40d, 0)]
+        [InlineData(1000d, 540d, 0)]
+        [InlineData(-1000d, -1459.7d, 1)]
+        [InlineData(0d, -459.67d, 2)]
+        [InlineData(50d, -409.7d, 1)]
+        [InlineData(100d, -359.7d, 1)]
+        [InlineData(500d, 40.32999999999998d, 14)]
+        [InlineData(1000d, 540.33d, 2)]
+        public void Test_double_extension_with_parameter_from_rankine_and_to_fahrenheit_returns_correct_double_value(double value, double expected, int fractionalCount)
+        {
+            // Arrange.
+            // Act.
+            var result = value.FromRankine().ToFahrenheit(fractionalCount);
+
+            // Assert.
+            result.Should().Be(expected);
+        }
+
+        [Theory]
+        [InlineData(-1000d, -1459.67d, -1)]
+        [InlineData(0d, -459.67d, -1)]
+        [InlineData(50d, -409.67d, -1)]
+        [InlineData(100d, -359.67d, -1)]
+        [InlineData(500d, 40.329999999999984d, -1)]
+        [InlineData(1000d, 540.3299999999999d, -1)]
+        [InlineData(-1000d, -1460d, 0)]
+        [InlineData(0d, -460d, 0)]
+        [InlineData(50d, -410d, 0)]
+        [InlineData(100d, -360d, 0)]
+        [InlineData(500d, 40d, 0)]
+        [InlineData(1000d, 540d, 0)]
+        [InlineData(-1000d, -1459.7d, 1)]
+        [InlineData(0d, -459.67d, 2)]
+        [InlineData(50d, -409.7d, 1)]
+        [InlineData(100d, -359.7d, 1)]
+        [InlineData(500d, 40.32999999999998d, 14)]
+        [InlineData(1000d, 540.33d, 2)]
+        public void Test_double_extension_generic_with_parameter_from_rankine_and_to_fahrenheit_returns_correct_double_value(double value, double expected, int fractionalCount)
+        {
+            // Arrange.
+            // Act.
+            var result = value.From<Rankine>().To<Fahrenheit>(fractionalCount);
 
             // Assert.
             result.Should().Be(expected);

--- a/Tests/Converter.Temperature.Integration.Tests/DoubleTests/ToKelvinDoubleTests.cs
+++ b/Tests/Converter.Temperature.Integration.Tests/DoubleTests/ToKelvinDoubleTests.cs
@@ -203,6 +203,62 @@
             result.Should().Be(expected);
         }
 
+        [Theory]
+        [InlineData(-1000d, -555.5555555555555d, -1)]
+        [InlineData(0d, 0d, -1)]
+        [InlineData(50d, 27.77777777777778d, -1)]
+        [InlineData(100d, 55.55555555555556d, -1)]
+        [InlineData(500d, 277.77777777777777d, -1)]
+        [InlineData(1000d, 555.5555555555555d, -1)]
+        [InlineData(-1000d, -556d, 0)]
+        [InlineData(0d, 0d, 0)]
+        [InlineData(50d, 28d, 0)]
+        [InlineData(100d, 56d, 0)]
+        [InlineData(500d, 278d, 0)]
+        [InlineData(1000d, 556d, 0)]
+        [InlineData(-1000d, -555.6d, 1)]
+        [InlineData(50d, 27.7777777777778d, 13)]
+        [InlineData(100d, 55.5556d, 4)]
+        [InlineData(500d, 277.8d, 1)]
+        [InlineData(1000d, 555.5555556d, 7)]
+        public void Test_double_extension_with_parameter_from_rankine_and_to_kelvin_returns_correct_double_value(double value, double expected, int fractionalCount)
+        {
+            // Arrange.
+            // Act.
+            var result = value.FromRankine().ToKelvin(fractionalCount);
+
+            // Assert.
+            result.Should().Be(expected);
+        }
+
+        [Theory]
+        [InlineData(-1000d, -555.5555555555555d, -1)]
+        [InlineData(0d, 0d, -1)]
+        [InlineData(50d, 27.77777777777778d, -1)]
+        [InlineData(100d, 55.55555555555556d, -1)]
+        [InlineData(500d, 277.77777777777777d, -1)]
+        [InlineData(1000d, 555.5555555555555d, -1)]
+        [InlineData(-1000d, -556d, 0)]
+        [InlineData(0d, 0d, 0)]
+        [InlineData(50d, 28d, 0)]
+        [InlineData(100d, 56d, 0)]
+        [InlineData(500d, 278d, 0)]
+        [InlineData(1000d, 556d, 0)]
+        [InlineData(-1000d, -555.6d, 1)]
+        [InlineData(50d, 27.7777777777778d, 13)]
+        [InlineData(100d, 55.5556d, 4)]
+        [InlineData(500d, 277.8d, 1)]
+        [InlineData(1000d, 555.5555556d, 7)]
+        public void Test_double_extension_generic_with_parameter_from_rankine_and_to_kelvin_returns_correct_double_value(double value, double expected, int fractionalCount)
+        {
+            // Arrange.
+            // Act.
+            var result = value.From<Rankine>().To<Kelvin>(fractionalCount);
+
+            // Assert.
+            result.Should().Be(expected);
+        }
+
         #endregion From Rankine
     }
 }

--- a/Tests/Converter.Temperature.Integration.Tests/DoubleTests/ToRankineDoubleTests.cs
+++ b/Tests/Converter.Temperature.Integration.Tests/DoubleTests/ToRankineDoubleTests.cs
@@ -40,6 +40,38 @@
         }
 
         [Theory]
+        [InlineData(851.6699999999998d, -1)]
+        [InlineData(852d, 0)]
+        [InlineData(851.67d, 2)]
+        public void Test_double_extensions_with_parameter_from_celsius_to_rankine_returns_correct_value(double expected, int fractionCount)
+        {
+            // Arrange.
+            const double input = 200d;
+
+            // Act.
+            var result = input.FromCelsius().ToRankine(fractionCount);
+
+            // Assert.
+            result.Should().Be(expected);
+        }
+
+        [Theory]
+        [InlineData(851.6699999999998d, -1)]
+        [InlineData(852d, 0)]
+        [InlineData(851.67d, 2)]
+        public void Test_double_extensions_generic_with_parameter_from_celsius_to_rankine_returns_correct_value(double expected, int fractionCount)
+        {
+            // Arrange.
+            const double input = 200d;
+
+            // Act.
+            var result = input.From<Celsius>().To<Rankine>(fractionCount);
+
+            // Assert.
+            result.Should().Be(expected);
+        }
+
+        [Theory]
         [InlineData(double.MinValue)]
         [InlineData(double.MaxValue)]
         public void Test_double_extensions_from_celsius_to_rankine_with_invalid_parameter_throws_exception(double input)
@@ -92,6 +124,38 @@
 
             // Act.
             var result = input.From<Fahrenheit>().To<Rankine>();
+
+            // Assert.
+            result.Should().Be(expected);
+        }
+
+        [Theory]
+        [InlineData(851.6700000000001d, -1)]
+        [InlineData(852d, 0)]
+        [InlineData(851.67d, 2)]
+        public void Test_double_extensions_with_parameter_from_fahrenheit_to_rankine_returns_correct_value(double expected, int fractionCount)
+        {
+            // Arrange.
+            const double input = 392d;
+
+            // Act.
+            var result = input.FromFahrenheit().ToRankine(fractionCount);
+
+            // Assert.
+            result.Should().Be(expected);
+        }
+
+        [Theory]
+        [InlineData(851.6700000000001d, -1)]
+        [InlineData(852d, 0)]
+        [InlineData(851.67d, 2)]
+        public void Test_double_extensions_generic_with_parameter_from_fahrenheit_to_rankine_returns_correct_value(double expected, int fractionCount)
+        {
+            // Arrange.
+            const double input = 392d;
+
+            // Act.
+            var result = input.From<Fahrenheit>().To<Rankine>(fractionCount);
 
             // Assert.
             result.Should().Be(expected);
@@ -158,6 +222,38 @@
 
             // Act.
             var result = input.From<Gas>().To<Rankine>();
+
+            // Assert.
+            result.Should().Be(expected);
+        }
+
+        [Theory]
+        [InlineData(851.6699999999998d, -1)]
+        [InlineData(852d, 0)]
+        [InlineData(851.67d, 2)]
+        public void Test_double_extension_with_parameter_from_gas_to_rankine_returns_correct_value(double expected, int fractionCount)
+        {
+            // Arrange.
+            const double input = 6d;
+
+            // Act.
+            var result = input.FromGas().ToRankine(fractionCount);
+
+            // Assert.
+            result.Should().Be(expected);
+        }
+
+        [Theory]
+        [InlineData(851.6699999999998d, -1)]
+        [InlineData(852d, 0)]
+        [InlineData(851.67d, 2)]
+        public void Test_double_extension_generic_with_parameter_from_gas_to_rankine_returns_correct_value(double expected, int fractionCount)
+        {
+            // Arrange.
+            const double input = 6d;
+
+            // Act.
+            var result = input.From<Gas>().To<Rankine>(fractionCount);
 
             // Assert.
             result.Should().Be(expected);

--- a/Tests/Converter.Temperature.Integration.Tests/FloatTests/ToCelsiusFloatTests.cs
+++ b/Tests/Converter.Temperature.Integration.Tests/FloatTests/ToCelsiusFloatTests.cs
@@ -76,6 +76,34 @@
         }
 
         [Fact]
+        public void Test_float_extension_from_fahrenheit_with_parameter_that_is_ignored_and_to_celsius_with_min_value_returns_correct_float_value()
+        {
+            // Arrange.
+            const float expected = -1.8904574813251603E+38f;
+            const float input = float.MinValue;
+
+            // Act.
+            var result = input.FromFahrenheit().ToCelsius(1);
+
+            // Assert.
+            result.Should().Be(expected);
+        }
+
+        [Fact]
+        public void Test_float_extension_generic_from_fahrenheit_with_parameter_that_is_ignored_and_to_celsius_with_min_value_returns_correct_float_value()
+        {
+            // Arrange.
+            const float expected = -1.8904574813251603E+38f;
+            const float input = float.MinValue;
+
+            // Act.
+            var result = input.From<Fahrenheit>().To<Celsius>(1);
+
+            // Assert.
+            result.Should().Be(expected);
+        }
+
+        [Fact]
         public void Test_float_extensions_from_fahrenheit_to_celsius_returns_correct_float_value()
         {
             // Arrange.
@@ -111,7 +139,7 @@
         public void Test_float_extensions_from_kelvin_to_celsius_returns_correct_float_value()
         {
             // Arrange.
-            const float expected = 1.0f;
+            const float expected = 0.9999939f;
             const float input = 274.15f;
 
             // Act.
@@ -125,7 +153,7 @@
         public void Test_float_extensions_generic_from_kelvin_to_celsius_returns_correct_float_value()
         {
             // Arrange.
-            const float expected = 1.0f;
+            const float expected = 0.9999939f;
             const float input = 274.15f;
 
             // Act.
@@ -265,9 +293,9 @@
 
         [Theory]
         [InlineData(0f, -273.15f)]
-        [InlineData(-100f, -328.71f)]
-        [InlineData(100f, -217.59f)]
-        [InlineData(1000f, 282.41f)]
+        [InlineData(-100f, -328.70557f)]
+        [InlineData(100f, -217.59445f)]
+        [InlineData(1000f, 282.40555f)]
         public void Test_float_extension_from_rankine_to_celsius_returns_correct_float_value(float input, float expected)
         {
             // Arrange.
@@ -280,14 +308,56 @@
 
         [Theory]
         [InlineData(0f, -273.15f)]
-        [InlineData(-100f, -328.71f)]
-        [InlineData(100f, -217.59f)]
-        [InlineData(1000f, 282.41f)]
+        [InlineData(-100f, -328.70557f)]
+        [InlineData(100f, -217.59445f)]
+        [InlineData(1000f, 282.40555f)]
         public void Test_float_extension_generic_from_rankine_to_celsius_returns_correct_float_value(float input, float expected)
         {
             // Arrange.
             // Act.
             var result = input.From<Rankine>().To<Celsius>();
+
+            // Assert.
+            result.Should().Be(expected);
+        }
+
+        [Theory]
+        [InlineData(0f, -273.15f, -1)]
+        [InlineData(-100f, -328.70557f, -1)]
+        [InlineData(-100f, -328.7f, 1)]
+        [InlineData(-100f, -328.7056f, 4)]
+        [InlineData(100f, -217.59445f, -1)]
+        [InlineData(100f, -217.6f, 1)]
+        [InlineData(100f, -217.594f, 3)]
+        [InlineData(1000f, 282.40555f, -1)]
+        [InlineData(1000f, 282.4f, 1)]
+        [InlineData(1000f, 282.41f, 2)]
+        public void Test_float_extension_from_rankine_with_parameter_to_celsius_returns_correct_float_value(float input, float expected, int fractionalCount)
+        {
+            // Arrange.
+            // Act.
+            var result = input.FromRankine().ToCelsius(fractionalCount);
+
+            // Assert.
+            result.Should().Be(expected);
+        }
+
+        [Theory]
+        [InlineData(0f, -273.15f, -1)]
+        [InlineData(-100f, -328.70557f, -1)]
+        [InlineData(-100f, -328.7f, 1)]
+        [InlineData(-100f, -328.7056f, 4)]
+        [InlineData(100f, -217.59445f, -1)]
+        [InlineData(100f, -217.6f, 1)]
+        [InlineData(100f, -217.594f, 3)]
+        [InlineData(1000f, 282.40555f, -1)]
+        [InlineData(1000f, 282.4f, 1)]
+        [InlineData(1000f, 282.41f, 2)]
+        public void Test_float_extension_generic_from_rankine_with_parameter_to_celsius_returns_correct_float_value(float input, float expected, int fractionalCount)
+        {
+            // Arrange.
+            // Act.
+            var result = input.From<Rankine>().To<Celsius>(fractionalCount);
 
             // Assert.
             result.Should().Be(expected);

--- a/Tests/Converter.Temperature.Integration.Tests/FloatTests/ToFahrenheitFloatTests.cs
+++ b/Tests/Converter.Temperature.Integration.Tests/FloatTests/ToFahrenheitFloatTests.cs
@@ -109,7 +109,7 @@
         public void Test_float_extensions_from_kelvin_to_fahrenheit_returns_correct_float_value()
         {
             // Arrange.
-            const float expected = 33.8f;
+            const float expected = 33.799988f;
             const float input = 274.15f;
 
             // Act.
@@ -123,11 +123,43 @@
         public void Test_float_extensions_generic_from_kelvin_to_fahrenheit_returns_correct_float_value()
         {
             // Arrange.
-            const float expected = 33.8f;
+            const float expected = 33.799988f;
             const float input = 274.15f;
 
             // Act.
             var result = input.From<Kelvin>().To<Fahrenheit>();
+
+            // Assert.
+            result.Should().Be(expected);
+        }
+
+        [Theory]
+        [InlineData(33.799988f, -1)]
+        [InlineData(33.8f, 1)]
+        [InlineData(33.79999f, 5)]
+        public void Test_float_extensions_from_kelvin_with_parameter_to_fahrenheit_returns_correct_float_value(float expected, int fractionalCount)
+        {
+            // Arrange.
+            const float input = 274.15f;
+
+            // Act.
+            var result = input.FromKelvin().ToFahrenheit(fractionalCount);
+
+            // Assert.
+            result.Should().Be(expected);
+        }
+
+        [Theory]
+        [InlineData(33.799988f, -1)]
+        [InlineData(33.8f, 1)]
+        [InlineData(33.79999f, 5)]
+        public void Test_float_extensions_generic_from_kelvin_with_parameter_to_fahrenheit_returns_correct_float_value(float expected, int fractionalCount)
+        {
+            // Arrange.
+            const float input = 274.15f;
+
+            // Act.
+            var result = input.From<Kelvin>().To<Fahrenheit>(fractionalCount);
 
             // Assert.
             result.Should().Be(expected);

--- a/Tests/Converter.Temperature.Integration.Tests/StringTests/ToCelsiusStringTests.cs
+++ b/Tests/Converter.Temperature.Integration.Tests/StringTests/ToCelsiusStringTests.cs
@@ -294,6 +294,38 @@
             result.Should().Be(expected.ToString(CultureInfo.InvariantCulture));
         }
 
+        [Theory]
+        [InlineData(0, -273.15d, -1)]
+        [InlineData(50, -245.3722222222222d, -1)]
+        [InlineData(100, -217.59444444444446d, -1)]
+        [InlineData(500, 4.627777777777769d, -1)]
+        [InlineData(1000, 282.40555555555557d, -1)]
+        public void Test_string_extension_with_parameter_from_rankine_and_to_celsius_returns_correct_string_value(double value, double expected, int fractionalCount)
+        {
+            // Arrange.
+            // Act.
+            var result = value.ToString(CultureInfo.InvariantCulture).FromRankine().ToCelsius(fractionalCount);
+
+            // Assert.
+            result.Should().Be(expected.ToString(CultureInfo.InvariantCulture));
+        }
+
+        [Theory]
+        [InlineData(0, -273.15d, -1)]
+        [InlineData(50, -245.3722222222222d, -1)]
+        [InlineData(100, -217.59444444444446d, -1)]
+        [InlineData(500, 4.627777777777769d, -1)]
+        [InlineData(1000, 282.40555555555557d, -1)]
+        public void Test_string_extension_generic_with_parameter_from_rankine_and_to_celsius_returns_correct_string_value(double value, double expected, int fractionalCount)
+        {
+            // Arrange.
+            // Act.
+            var result = value.ToString(CultureInfo.InvariantCulture).From<Rankine>().To<Celsius>(fractionalCount);
+
+            // Assert.
+            result.Should().Be(expected.ToString(CultureInfo.InvariantCulture));
+        }
+
         #endregion From Rankine
     }
 }

--- a/Tests/Converter.Temperature.Integration.Tests/StringTests/ToFahrenheitStringTests.cs
+++ b/Tests/Converter.Temperature.Integration.Tests/StringTests/ToFahrenheitStringTests.cs
@@ -66,6 +66,44 @@
             result.Should().Be(expected);
         }
 
+        [Theory]
+        [InlineData("-152436784.334563", "-274386179.8022134", -1)]
+        [InlineData("0.0", "32", -1)]
+        [InlineData("26431662.73648262", "47577024.92566872", -1)]
+        [InlineData("-152436784.334563", "-274386180", 0)]
+        [InlineData("0.0", "32", 0)]
+        [InlineData("26431662.73648262", "47577025", 0)]
+        [InlineData("-152436784.334563", "-274386179.802", 3)]
+        [InlineData("26431662.73648262", "47577024.92567", 5)]
+        public void Test_string_extension_with_parameter_from_celsius_and_to_fahrenheit_returns_correct_string_value(string input, string expected, int fractionalCount)
+        {
+            // Arrange.
+            // Act.
+            var result = input.FromCelsius().ToFahrenheit(fractionalCount);
+
+            // Assert.
+            result.Should().Be(expected);
+        }
+
+        [Theory]
+        [InlineData("-152436784.334563", "-274386179.8022134", -1)]
+        [InlineData("0.0", "32", -1)]
+        [InlineData("26431662.73648262", "47577024.92566872", -1)]
+        [InlineData("-152436784.334563", "-274386180", 0)]
+        [InlineData("0.0", "32", 0)]
+        [InlineData("26431662.73648262", "47577025", 0)]
+        [InlineData("-152436784.334563", "-274386179.802", 3)]
+        [InlineData("26431662.73648262", "47577024.92567", 5)]
+        public void Test_string_extension_generic_with_parameter_from_celsius_and_to_fahrenheit_returns_correct_string_value(string input, string expected, int fractionalCount)
+        {
+            // Arrange.
+            // Act.
+            var result = input.From<Celsius>().To<Fahrenheit>(fractionalCount);
+
+            // Assert.
+            result.Should().Be(expected);
+        }
+
         #endregion From Celsius
 
         #region From Fahrenheit
@@ -225,6 +263,64 @@
             // Arrange.
             // Act.
             var result = value.ToString(CultureInfo.InvariantCulture).From<Rankine>().To<Fahrenheit>();
+
+            // Assert.
+            result.Should().Be(expected.ToString(CultureInfo.InvariantCulture));
+        }
+
+        [Theory]
+        [InlineData(-1000d, -1459.67d, -1)]
+        [InlineData(0d, -459.67d, -1)]
+        [InlineData(50d, -409.67d, -1)]
+        [InlineData(100d, -359.67d, -1)]
+        [InlineData(500d, 40.329999999999984d, -1)]
+        [InlineData(1000d, 540.3299999999999d, -1)]
+        [InlineData(-1000d, -1460d, 0)]
+        [InlineData(0d, -460d, 0)]
+        [InlineData(50d, -410d, 0)]
+        [InlineData(100d, -360d, 0)]
+        [InlineData(500d, 40d, 0)]
+        [InlineData(1000d, 540d, 0)]
+        [InlineData(-1000d, -1459.7d, 1)]
+        [InlineData(0d, -459.7d, 1)]
+        [InlineData(50d, -409.67d, 2)]
+        [InlineData(100d, -359.67d, 2)]
+        [InlineData(500d, 40.32999999999998d, 14)]
+        [InlineData(1000d, 540.33d, 2)]
+        public void Test_string_extension_with_parameter_from_rankine_and_to_fahrenheit_returns_correct_string_value(double value, double expected, int fractionalCount)
+        {
+            // Arrange.
+            // Act.
+            var result = value.ToString(CultureInfo.InvariantCulture).FromRankine().ToFahrenheit(fractionalCount);
+
+            // Assert.
+            result.Should().Be(expected.ToString(CultureInfo.InvariantCulture));
+        }
+
+        [Theory]
+        [InlineData(-1000d, -1459.67d, -1)]
+        [InlineData(0d, -459.67d, -1)]
+        [InlineData(50d, -409.67d, -1)]
+        [InlineData(100d, -359.67d, -1)]
+        [InlineData(500d, 40.329999999999984d, -1)]
+        [InlineData(1000d, 540.3299999999999d, -1)]
+        [InlineData(-1000d, -1460d, 0)]
+        [InlineData(0d, -460d, 0)]
+        [InlineData(50d, -410d, 0)]
+        [InlineData(100d, -360d, 0)]
+        [InlineData(500d, 40d, 0)]
+        [InlineData(1000d, 540d, 0)]
+        [InlineData(-1000d, -1459.7d, 1)]
+        [InlineData(0d, -459.7d, 1)]
+        [InlineData(50d, -409.67d, 2)]
+        [InlineData(100d, -359.67d, 2)]
+        [InlineData(500d, 40.32999999999998d, 14)]
+        [InlineData(1000d, 540.33d, 2)]
+        public void Test_string_extension_generic_with_parameter_from_rankine_and_to_fahrenheit_returns_correct_string_value(double value, double expected, int fractionalCount)
+        {
+            // Arrange.
+            // Act.
+            var result = value.ToString(CultureInfo.InvariantCulture).From<Rankine>().To<Fahrenheit>(fractionalCount);
 
             // Assert.
             result.Should().Be(expected.ToString(CultureInfo.InvariantCulture));

--- a/Tests/Converter.Temperature.Integration.Tests/StringTests/ToKelvinStringTests.cs
+++ b/Tests/Converter.Temperature.Integration.Tests/StringTests/ToKelvinStringTests.cs
@@ -204,6 +204,62 @@
             result.Should().Be(expected.ToString(CultureInfo.InvariantCulture));
         }
 
+        [Theory]
+        [InlineData(-1000d, -555.5555555555555d, -1)]
+        [InlineData(0d, 0d, -1)]
+        [InlineData(50d, 27.77777777777778d, -1)]
+        [InlineData(100d, 55.55555555555556d, -1)]
+        [InlineData(500d, 277.77777777777777d, -1)]
+        [InlineData(1000d, 555.5555555555555d, -1)]
+        [InlineData(-1000d, -556d, 0)]
+        [InlineData(0d, 0d, 0)]
+        [InlineData(50d, 28d, 0)]
+        [InlineData(100d, 56d, 0)]
+        [InlineData(500d, 278d, 0)]
+        [InlineData(1000d, 556d, 0)]
+        [InlineData(-1000d, -555.56d, 2)]
+        [InlineData(50d, 27.778d, 3)]
+        [InlineData(100d, 55.5556d, 4)]
+        [InlineData(500d, 277.77778d, 5)]
+        [InlineData(1000d, 555.555556d, 6)]
+        public void Test_string_extension_with_parameter_from_rankine_and_to_kelvin_returns_correct_string_value(double value, double expected, int fractionalCount)
+        {
+            // Arrange.
+            // Act.
+            var result = value.ToString(CultureInfo.InvariantCulture).FromRankine().ToKelvin(fractionalCount);
+
+            // Assert.
+            result.Should().Be(expected.ToString(CultureInfo.InvariantCulture));
+        }
+
+        [Theory]
+        [InlineData(-1000d, -555.5555555555555d, -1)]
+        [InlineData(0d, 0d, -1)]
+        [InlineData(50d, 27.77777777777778d, -1)]
+        [InlineData(100d, 55.55555555555556d, -1)]
+        [InlineData(500d, 277.77777777777777d, -1)]
+        [InlineData(1000d, 555.5555555555555d, -1)]
+        [InlineData(-1000d, -556d, 0)]
+        [InlineData(0d, 0d, 0)]
+        [InlineData(50d, 28d, 0)]
+        [InlineData(100d, 56d, 0)]
+        [InlineData(500d, 278d, 0)]
+        [InlineData(1000d, 556d, 0)]
+        [InlineData(-1000d, -555.56d, 2)]
+        [InlineData(50d, 27.778d, 3)]
+        [InlineData(100d, 55.5556d, 4)]
+        [InlineData(500d, 277.77778d, 5)]
+        [InlineData(1000d, 555.555556d, 6)]
+        public void Test_string_extension_generic_with_parameter_from_rankine_and_to_kelvin_returns_correct_string_value(double value, double expected, int fractionalCount)
+        {
+            // Arrange.
+            // Act.
+            var result = value.ToString(CultureInfo.InvariantCulture).From<Rankine>().To<Kelvin>(fractionalCount);
+
+            // Assert.
+            result.Should().Be(expected.ToString(CultureInfo.InvariantCulture));
+        }
+
         #endregion From Rankine
     }
 }

--- a/Tests/Converter.Temperature.Integration.Tests/StringTests/ToRankineStringTests.cs
+++ b/Tests/Converter.Temperature.Integration.Tests/StringTests/ToRankineStringTests.cs
@@ -41,6 +41,38 @@
         }
 
         [Theory]
+        [InlineData("851.6699999999998", -1)]
+        [InlineData("852", 0)]
+        [InlineData("851.67", 2)]
+        public void Test_string_extensions_with_parameter_from_celsius_to_rankine_returns_correct_value(string expected, int fractionalCount)
+        {
+            // Arrange.
+            const string input = "200";
+
+            // Act.
+            var result = input.FromCelsius().ToRankine(fractionalCount);
+
+            // Assert.
+            result.Should().Be(expected);
+        }
+
+        [Theory]
+        [InlineData("851.6699999999998", -1)]
+        [InlineData("852", 0)]
+        [InlineData("851.67", 2)]
+        public void Test_string_extensions_generic_with_parameter_from_celsius_to_rankine_returns_correct_value(string expected, int fractionalCount)
+        {
+            // Arrange.
+            const string input = "200";
+
+            // Act.
+            var result = input.From<Celsius>().To<Rankine>(fractionalCount);
+
+            // Assert.
+            result.Should().Be(expected);
+        }
+
+        [Theory]
         [InlineData(double.MinValue)]
         [InlineData(double.MaxValue)]
         public void Test_string_extensions_from_celsius_to_rankine_with_invalid_parameter_throws_exception(double input)
@@ -93,6 +125,38 @@
 
             // Act.
             var result = input.From<Fahrenheit>().To<Rankine>();
+
+            // Assert.
+            result.Should().Be(expected);
+        }
+
+        [Theory]
+        [InlineData("851.6700000000001", -1)]
+        [InlineData("852", 0)]
+        [InlineData("851.7", 1)]
+        public void Test_string_extensions_with_parameter_from_fahrenheit_to_rankine_returns_correct_value(string expected, int fractionalCount)
+        {
+            // Arrange.
+            const string input = "392";
+
+            // Act.
+            var result = input.FromFahrenheit().ToRankine(fractionalCount);
+
+            // Assert.
+            result.Should().Be(expected);
+        }
+
+        [Theory]
+        [InlineData("851.6700000000001", -1)]
+        [InlineData("852", 0)]
+        [InlineData("851.7", 1)]
+        public void Test_string_extensions_generic_with_parameter_from_fahrenheit_to_rankine_returns_correct_value(string expected, int fractionalCount)
+        {
+            // Arrange.
+            const string input = "392";
+
+            // Act.
+            var result = input.From<Fahrenheit>().To<Rankine>(fractionalCount);
 
             // Assert.
             result.Should().Be(expected);

--- a/Tests/Converter.Temperature.Tests/Extensions/To/ToDoubleExtensionsTests.cs
+++ b/Tests/Converter.Temperature.Tests/Extensions/To/ToDoubleExtensionsTests.cs
@@ -223,6 +223,36 @@
             result.Should().Be(expected);
         }
 
+        [Theory]
+        [InlineData(1.0d, 1)]
+        [InlineData(1.00000000000001d, 14)]
+        public void Test_to_celsius_with_parameter_from_rankine_returns_correct_value(double expected, int fractionalCount)
+        {
+            // Arrange.
+            var input = new RankineDouble(493.47d);
+
+            // Act.
+            var result = input.ToCelsius(fractionalCount);
+
+            // Assert.
+            result.Should().Be(expected);
+        }
+
+        [Theory]
+        [InlineData(1.0d, 1)]
+        [InlineData(1.00000000000001d, 14)]
+        public void Test_to_celsius_generic_with_parameter_from_rankine_returns_correct_value(double expected, int fractionalCount)
+        {
+            // Arrange.
+            var input = new RankineDouble(493.47d);
+
+            // Act.
+            var result = input.To<Celsius>(fractionalCount);
+
+            // Assert.
+            result.Should().Be(expected);
+        }
+
         [Fact]
         public void Test_to_fahrenheit_from_celsius_returns_correct_value()
         {
@@ -363,6 +393,36 @@
             result.Should().Be(expected);
         }
 
+        [Theory]
+        [InlineData(33.8d, 1)]
+        [InlineData(34d, 0)]
+        public void Test_to_fahrenheit_with_parameter_from_kelvin_returns_correct_value(double expected, int fractionalCount)
+        {
+            // Arrange.
+            var input = new KelvinDouble(274.15);
+
+            // Act.
+            var result = input.ToFahrenheit(fractionalCount);
+
+            // Assert.
+            result.Should().Be(expected);
+        }
+
+        [Theory]
+        [InlineData(33.8d, 1)]
+        [InlineData(34d, 0)]
+        public void Test_to_fahrenheit_generic_with_parameter_from_kelvin_returns_correct_value(double expected, int fractionalCount)
+        {
+            // Arrange.
+            var input = new KelvinDouble(274.15);
+
+            // Act.
+            var result = input.To<Fahrenheit>(fractionalCount);
+
+            // Assert.
+            result.Should().Be(expected);
+        }
+
         [Fact]
         public void Test_to_fahrenheit_from_rankine_returns_correct_value()
         {
@@ -386,6 +446,38 @@
 
             // Act.
             var result = input.To<Fahrenheit>();
+
+            // Assert.
+            result.Should().Be(expected);
+        }
+
+        [Theory]
+        [InlineData(33.800999999999991d, -1)]
+        [InlineData(34d, 0)]
+        [InlineData(33.801d, 3)]
+        public void Test_to_fahrenheit_with_parameter_from_rankine_returns_correct_value(double expected, int fractionalCount)
+        {
+            // Arrange.
+            var input = new RankineDouble(493.471d);
+
+            // Act.
+            var result = input.ToFahrenheit(fractionalCount);
+
+            // Assert.
+            result.Should().Be(expected);
+        }
+
+        [Theory]
+        [InlineData(33.800999999999991d, -1)]
+        [InlineData(34d, 0)]
+        [InlineData(33.801d, 3)]
+        public void Test_to_fahrenheit_generic_with_parameter_from_rankine_returns_correct_value(double expected, int fractionalCount)
+        {
+            // Arrange.
+            var input = new RankineDouble(493.471d);
+
+            // Act.
+            var result = input.To<Fahrenheit>(fractionalCount);
 
             // Assert.
             result.Should().Be(expected);
@@ -730,6 +822,38 @@
 
             // Act.
             var result = input.To<Kelvin>();
+
+            // Assert.
+            result.Should().Be(expected);
+        }
+
+        [Theory]
+        [InlineData(473.15d, -1)]
+        [InlineData(473d, 0)]
+        [InlineData(473.2d, 1)]
+        public void Test_to_kelvin_with_parameter_from_gas_returns_correct_value(double expected, int fractionalCount)
+        {
+            // Arrange.
+            var input = new GasDouble(6);
+
+            // Act.
+            var result = input.ToKelvin(fractionalCount);
+
+            // Assert.
+            result.Should().Be(expected);
+        }
+
+        [Theory]
+        [InlineData(473.15d, -1)]
+        [InlineData(473d, 0)]
+        [InlineData(473.2d, 1)]
+        public void Test_to_kelvin_generic_with_parameter_from_gas_returns_correct_value(double expected, int fractionalCount)
+        {
+            // Arrange.
+            var input = new GasDouble(6);
+
+            // Act.
+            var result = input.To<Kelvin>(fractionalCount);
 
             // Assert.
             result.Should().Be(expected);

--- a/Tests/Converter.Temperature.Tests/Extensions/To/ToDoubleExtensionsTests.cs
+++ b/Tests/Converter.Temperature.Tests/Extensions/To/ToDoubleExtensionsTests.cs
@@ -14,6 +14,19 @@
     public class ToDoubleExtensionsTests
     {
         [Fact]
+        public void Test_to_celsius_with_too_long_parameter_from_celsius_throws_exception()
+        {
+            // Arrange.
+            var input = new CelsiusDouble(42.5d);
+
+            // Act.
+            var result = Assert.Throws<ArgumentOutOfRangeException>(() => input.ToCelsius(16));
+
+            // Assert.
+            result.Message.Should().Contain("Rounding digits must be between 0 and 15, inclusive.");
+        }
+
+        [Fact]
         public void Test_to_celsius_from_celsius_returns_same_value()
         {
             // Arrange.

--- a/Tests/Converter.Temperature.Tests/Extensions/To/ToFloatExtensionsTests.cs
+++ b/Tests/Converter.Temperature.Tests/Extensions/To/ToFloatExtensionsTests.cs
@@ -135,7 +135,7 @@
         public void Test_to_celsius_from_kelvin_returns_correct_value()
         {
             // Arrange.
-            const float expected = 1.0f;
+            const float expected = 0.9999939f;
             var input = new KelvinFloat(274.15f);
 
             // Act.
@@ -149,7 +149,7 @@
         public void Test_to_celsius_generic_from_kelvin_returns_correct_value()
         {
             // Arrange.
-            const float expected = 1.0f;
+            const float expected = 0.9999939f;
             var input = new KelvinFloat(274.15f);
 
             // Act.
@@ -159,11 +159,41 @@
             result.Should().Be(expected);
         }
 
+        [Theory]
+        [InlineData(1.0f, 1)]
+        [InlineData(0.999994f, 6)]
+        public void Test_to_celsius_with_parameter_from_kelvin_returns_correct_value(float expected, int fractionalCount)
+        {
+            // Arrange.
+            var input = new KelvinFloat(274.15f);
+
+            // Act.
+            var result = input.ToCelsius(fractionalCount);
+
+            // Assert.
+            result.Should().Be(expected);
+        }
+
+        [Theory]
+        [InlineData(1.0f, 1)]
+        [InlineData(0.999994f, 6)]
+        public void Test_to_celsius_generic_parameter_from_kelvin_returns_correct_value(float expected, int fractionalCount)
+        {
+            // Arrange.
+            var input = new KelvinFloat(274.15f);
+
+            // Act.
+            var result = input.To<Celsius>(fractionalCount);
+
+            // Assert.
+            result.Should().Be(expected);
+        }
+
         [Fact]
         public void Test_to_celsius_from_rankine_returns_correct_value()
         {
             // Arrange.
-            const float expected = 1f;
+            const float expected = 1.0000007f;
             var input = new RankineFloat(493.47f);
 
             // Act.
@@ -177,11 +207,41 @@
         public void Test_to_celsius_generic_from_rankine_returns_correct_value()
         {
             // Arrange.
-            const float expected = 1f;
+            const float expected = 1.0000007f;
             var input = new RankineFloat(493.47f);
 
             // Act.
             var result = input.To<Celsius>();
+
+            // Assert.
+            result.Should().Be(expected);
+        }
+
+        [Theory]
+        [InlineData(1.0f, 1)]
+        [InlineData(1.000001f, 6)]
+        public void Test_to_celsius_with_parameter_from_rankine_returns_correct_value(float expected, int fractionalCount)
+        {
+            // Arrange.
+            var input = new RankineFloat(493.47f);
+
+            // Act.
+            var result = input.ToCelsius(fractionalCount);
+
+            // Assert.
+            result.Should().Be(expected);
+        }
+
+        [Theory]
+        [InlineData(1.0f, 1)]
+        [InlineData(1.000001f, 6)]
+        public void Test_to_celsius_generic_with_parameter_from_rankine_returns_correct_value(float expected, int fractionalCount)
+        {
+            // Arrange.
+            var input = new RankineFloat(493.47f);
+
+            // Act.
+            var result = input.To<Celsius>(fractionalCount);
 
             // Assert.
             result.Should().Be(expected);
@@ -241,6 +301,36 @@
             result.Should().Be(input.Temperature);
         }
 
+        [Theory]
+        [InlineData(50.5f, 1)]
+        [InlineData(50.46f, 2)]
+        public void Test_to_fahrenheit_with_round_parameter_from_fahrenheit_returns_correct_value(float expected, int fractionalCount)
+        {
+            // Arrange.
+            var input = new FahrenheitFloat(50.456f);
+
+            // Act.
+            var result = input.ToFahrenheit(fractionalCount);
+
+            // Assert.
+            result.Should().Be(expected);
+        }
+
+        [Theory]
+        [InlineData(50.5f, 1)]
+        [InlineData(50.46f, 2)]
+        public void Test_to_fahrenheit_generic_parameter_from_fahrenheit_returns_correct_value(float expected, int fractionalCount)
+        {
+            // Arrange.
+            var input = new FahrenheitFloat(50.456f);
+
+            // Act.
+            var result = input.To<Fahrenheit>(fractionalCount);
+
+            // Assert.
+            result.Should().Be(expected);
+        }
+
         [Fact]
         public void Test_to_fahrenheit_from_gas_returns_correct_value()
         {
@@ -273,7 +363,7 @@
         public void Test_to_fahrenheit_from_kelvin_returns_correct_value()
         {
             // Arrange.
-            const float expected = 33.8f;
+            const float expected = 33.799988f;
             var input = new KelvinFloat(274.15f);
 
             // Act.
@@ -287,7 +377,7 @@
         public void Test_to_fahrenheit_generic_from_kelvin_returns_correct_value()
         {
             // Arrange.
-            const float expected = 33.8f;
+            const float expected = 33.799988f;
             var input = new KelvinFloat(274.15f);
 
             // Act.
@@ -335,6 +425,36 @@
 
             // Act.
             var result = input.To<Fahrenheit>();
+
+            // Assert.
+            result.Should().Be(expected);
+        }
+
+        [Theory]
+        [InlineData(33.8f, 1)]
+        [InlineData(33.801f, 3)]
+        public void Test_to_fahrenheit_with_parameter_from_rankine_returns_correct_value(float expected, int fractionalCount)
+        {
+            // Arrange.
+            var input = new RankineFloat(493.471f);
+
+            // Act.
+            var result = input.ToFahrenheit(fractionalCount);
+
+            // Assert.
+            result.Should().Be(expected);
+        }
+
+        [Theory]
+        [InlineData(33.8f, 1)]
+        [InlineData(33.801f, 3)]
+        public void Test_to_fahrenheit_generic_with_parameter_from_rankine_returns_correct_value(float expected, int fractionalCount)
+        {
+            // Arrange.
+            var input = new RankineFloat(493.471f);
+
+            // Act.
+            var result = input.To<Fahrenheit>(fractionalCount);
 
             // Assert.
             result.Should().Be(expected);

--- a/Tests/Converter.Temperature.Tests/Extensions/To/ToFloatExtensionsTests.cs
+++ b/Tests/Converter.Temperature.Tests/Extensions/To/ToFloatExtensionsTests.cs
@@ -177,7 +177,7 @@
         [Theory]
         [InlineData(1.0f, 1)]
         [InlineData(0.999994f, 6)]
-        public void Test_to_celsius_generic_parameter_from_kelvin_returns_correct_value(float expected, int fractionalCount)
+        public void Test_to_celsius_generic_with_parameter_from_kelvin_returns_correct_value(float expected, int fractionalCount)
         {
             // Arrange.
             var input = new KelvinFloat(274.15f);

--- a/src/Converter.Temperature/Extensions/To/ToDoubleExtensions.cs
+++ b/src/Converter.Temperature/Extensions/To/ToDoubleExtensions.cs
@@ -19,6 +19,7 @@
         /// </summary>
         /// <param name="input"> The value to be converted. </param>
         /// <param name="fractionalCount"> The count of fractional after the decimal point. </param>
+        /// <exception cref="ArgumentOutOfRangeException"> If fractional count is greater than 15. </exception>
         /// <returns>
         /// The Celsius <see langword="double"/> result.
         /// </returns>
@@ -32,7 +33,8 @@
         /// </summary>
         /// <param name="input"> The value to be converted. </param>
         /// <param name="fractionalCount"> The count of fractional after the decimal point. </param>
-        /// <exception cref="T:System.ArgumentOutOfRangeException">If calculated value is beyond the limits of the type.</exception>
+        /// <exception cref="ArgumentOutOfRangeException"> If calculated value is beyond the limits of the type. </exception>
+        /// <exception cref="ArgumentOutOfRangeException"> If fractional count is greater than 15. </exception>
         /// <returns>
         /// The Celsius <see langword="double"/> result.
         /// </returns>
@@ -46,7 +48,8 @@
         /// </summary>
         /// <param name="input"> The value to be converted. </param>
         /// <param name="fractionalCount"> The count of fractional after the decimal point. </param>
-        /// <exception cref="T:System.ArgumentOutOfRangeException">Temp too low or too high for gas mark!</exception>
+        /// <exception cref="ArgumentOutOfRangeException"> Temp too low or too high for gas mark! </exception>
+        /// <exception cref="ArgumentOutOfRangeException"> If fractional count is greater than 15. </exception>
         /// <returns>
         /// The Celsius <see langword="double"/> result.
         /// </returns>
@@ -60,6 +63,7 @@
         /// </summary>
         /// <param name="input"> The value to be converted. </param>
         /// <param name="fractionalCount"> The count of fractional after the decimal point. </param>
+        /// <exception cref="ArgumentOutOfRangeException"> If fractional count is greater than 15. </exception>
         /// <returns>
         /// The Celsius <see langword="double"/> result.
         /// </returns>
@@ -73,6 +77,7 @@
         /// </summary>
         /// <param name="input"> The value to be converted. </param>
         /// <param name="fractionalCount"> The count of fractional after the decimal point. </param>
+        /// <exception cref="ArgumentOutOfRangeException"> If fractional count is greater than 15. </exception>
         /// <returns>
         /// The Celsius <see langword="double"/> result.
         /// </returns>
@@ -86,7 +91,8 @@
         /// </summary>
         /// <param name="input"> The value to be converted. </param>
         /// <param name="fractionalCount"> The count of fractional after the decimal point. </param>
-        /// <exception cref="T:System.ArgumentOutOfRangeException">If calculated value is beyond the limits of the type.</exception>
+        /// <exception cref="ArgumentOutOfRangeException"> If calculated value is beyond the limits of the type. </exception>
+        /// <exception cref="ArgumentOutOfRangeException"> If fractional count is greater than 15. </exception>
         /// <returns>
         /// The FahrenheitConverter <see langword="double"/> result.
         /// </returns>
@@ -100,6 +106,7 @@
         /// </summary>
         /// <param name="input"> The value to be converted. </param>
         /// <param name="fractionalCount"> The count of fractional after the decimal point. </param>
+        /// <exception cref="ArgumentOutOfRangeException"> If fractional count is greater than 15. </exception>
         /// <returns>
         /// The FahrenheitConverter <see langword="double"/> result.
         /// </returns>
@@ -113,7 +120,8 @@
         /// </summary>
         /// <param name="input"> The value to be converted. </param>
         /// <param name="fractionalCount"> The count of fractional after the decimal point. </param>
-        /// <exception cref="T:System.ArgumentOutOfRangeException">Temp too low or too high for gas mark!</exception>
+        /// <exception cref="ArgumentOutOfRangeException"> Temp too low or too high for gas mark! </exception>
+        /// <exception cref="ArgumentOutOfRangeException"> If fractional count is greater than 15. </exception>
         /// <returns>
         /// The FahrenheitConverter <see langword="double"/> result.
         /// </returns>
@@ -127,7 +135,8 @@
         /// </summary>
         /// <param name="input"> The value to be converted. </param>
         /// <param name="fractionalCount"> The count of fractional after the decimal point. </param>
-        /// <exception cref="T:System.ArgumentOutOfRangeException">If calculated value is beyond the limits of the type.</exception>
+        /// <exception cref="ArgumentOutOfRangeException"> If calculated value is beyond the limits of the type. </exception>
+        /// <exception cref="ArgumentOutOfRangeException"> If fractional count is greater than 15. </exception>
         /// <returns>
         /// The FahrenheitConverter <see langword="double"/> result.
         /// </returns>
@@ -141,7 +150,8 @@
         /// </summary>
         /// <param name="input"> The value to be converted. </param>
         /// <param name="fractionalCount"> The count of fractional after the decimal point. </param>
-        /// <exception cref="T:System.ArgumentOutOfRangeException">If calculated value is beyond the limits of the type.</exception>
+        /// <exception cref="ArgumentOutOfRangeException"> If calculated value is beyond the limits of the type. </exception>
+        /// <exception cref="ArgumentOutOfRangeException"> If fractional count is greater than 15. </exception>
         /// <returns>
         /// The FahrenheitConverter <see langword="double"/> result.
         /// </returns>
@@ -155,7 +165,8 @@
         /// </summary>
         /// <param name="input"> The value to be converted. </param>
         /// <param name="fractionalCount"> The count of fractional after the decimal point. </param>
-        /// <exception cref="T:System.ArgumentOutOfRangeException">Temp too low or too high for gas mark!</exception>
+        /// <exception cref="ArgumentOutOfRangeException"> Temp too low or too high for gas mark! </exception>
+        /// <exception cref="ArgumentOutOfRangeException"> If fractional count is greater than 15. </exception>
         /// <returns>
         /// The GasConverter <see langword="double"/> result.
         /// </returns>
@@ -169,7 +180,8 @@
         /// </summary>
         /// <param name="input"> The value to be converted. </param>
         /// <param name="fractionalCount"> The count of fractional after the decimal point. </param>
-        /// <exception cref="T:System.ArgumentOutOfRangeException">Temp too low or too high for gas mark!</exception>
+        /// <exception cref="ArgumentOutOfRangeException"> Temp too low or too high for gas mark! </exception>
+        /// <exception cref="ArgumentOutOfRangeException"> If fractional count is greater than 15. </exception>
         /// <returns>
         /// The GasConverter <see langword="double"/> result.
         /// </returns>
@@ -183,7 +195,8 @@
         /// </summary>
         /// <param name="input"> The value to be converted. </param>
         /// <param name="fractionalCount"> The count of fractional after the decimal point. </param>
-        /// <exception cref="T:System.ArgumentOutOfRangeException">Temp too low or too high for gas mark!</exception>
+        /// <exception cref="ArgumentOutOfRangeException"> Temp too low or too high for gas mark! </exception>
+        /// <exception cref="ArgumentOutOfRangeException"> If fractional count is greater than 15. </exception>
         /// <returns>
         /// The GasConverter <see langword="double"/> result.
         /// </returns>
@@ -197,7 +210,8 @@
         /// </summary>
         /// <param name="input"> The value to be converted. </param>
         /// <param name="fractionalCount"> The count of fractional after the decimal point. </param>
-        /// <exception cref="T:System.ArgumentOutOfRangeException">Temp too low or too high for gas mark!</exception>
+        /// <exception cref="ArgumentOutOfRangeException"> Temp too low or too high for gas mark! </exception>
+        /// <exception cref="ArgumentOutOfRangeException"> If fractional count is greater than 15. </exception>
         /// <returns>
         /// The GasConverter <see langword="double"/> result.
         /// </returns>
@@ -211,7 +225,8 @@
         /// </summary>
         /// <param name="input"> The value to be converted. </param>
         /// <param name="fractionalCount"> The count of fractional after the decimal point. </param>
-        /// <exception cref="T:System.ArgumentOutOfRangeException">Temp too low or too high for gas mark!</exception>
+        /// <exception cref="ArgumentOutOfRangeException"> Temp too low or too high for gas mark! </exception>
+        /// <exception cref="ArgumentOutOfRangeException"> If fractional count is greater than 15. </exception>
         /// <returns>
         /// The GasConverter <see langword="double"/> result.
         /// </returns>
@@ -225,7 +240,8 @@
         /// </summary>
         /// <param name="input"> The value to be converted. </param>
         /// <param name="fractionalCount"> The count of fractional after the decimal point. </param>
-        /// <exception cref="T:System.ArgumentOutOfRangeException">If calculated value is beyond the limits of the type.</exception>
+        /// <exception cref="ArgumentOutOfRangeException"> If calculated value is beyond the limits of the type. </exception>
+        /// <exception cref="ArgumentOutOfRangeException"> If fractional count is greater than 15. </exception>
         /// <returns>
         /// The KelvinConverter <see langword="double"/> result.
         /// </returns>
@@ -239,7 +255,8 @@
         /// </summary>
         /// <param name="input"> The value to be converted. </param>
         /// <param name="fractionalCount"> The count of fractional after the decimal point. </param>
-        /// <exception cref="T:System.ArgumentOutOfRangeException">If calculated value is beyond the limits of the type.</exception>
+        /// <exception cref="ArgumentOutOfRangeException"> If calculated value is beyond the limits of the type. </exception>
+        /// <exception cref="ArgumentOutOfRangeException"> If fractional count is greater than 15. </exception>
         /// <returns>
         /// The KelvinConverter <see langword="double"/> result.
         /// </returns>
@@ -253,7 +270,8 @@
         /// </summary>
         /// <param name="input"> The value to be converted. </param>
         /// <param name="fractionalCount"> The count of fractional after the decimal point. </param>
-        /// <exception cref="T:System.ArgumentOutOfRangeException">Temp too low or too high for gas mark!</exception>
+        /// <exception cref="ArgumentOutOfRangeException"> Temp too low or too high for gas mark! </exception>
+        /// <exception cref="ArgumentOutOfRangeException"> If fractional count is greater than 15. </exception>
         /// <returns>
         /// The KelvinConverter <see langword="double"/> result.
         /// </returns>
@@ -267,6 +285,7 @@
         /// </summary>
         /// <param name="input"> The value to be converted. </param>
         /// <param name="fractionalCount"> The count of fractional after the decimal point. </param>
+        /// <exception cref="ArgumentOutOfRangeException"> If fractional count is greater than 15. </exception>
         /// <returns>
         /// The KelvinConverter <see langword="double"/> result.
         /// </returns>
@@ -280,7 +299,8 @@
         /// </summary>
         /// <param name="input"> The value to be converted. </param>
         /// <param name="fractionalCount"> The count of fractional after the decimal point. </param>
-        /// <exception cref="T:System.ArgumentOutOfRangeException">If calculated value is beyond the limits of the type.</exception>
+        /// <exception cref="ArgumentOutOfRangeException"> If calculated value is beyond the limits of the type. </exception>
+        /// <exception cref="ArgumentOutOfRangeException"> If fractional count is greater than 15. </exception>
         /// <returns>
         /// The KelvinConverter <see langword="double"/> result.
         /// </returns>
@@ -294,6 +314,7 @@
         /// </summary>
         /// <param name="input"> The value to be converted. </param>
         /// <param name="fractionalCount"> The count of fractional after the decimal point. </param>
+        /// <exception cref="ArgumentOutOfRangeException"> If fractional count is greater than 15. </exception>
         /// <returns>
         /// The RankineConverter <see langword="double"/> result.
         /// </returns>
@@ -307,6 +328,7 @@
         /// </summary>
         /// <param name="input"> The value to be converted. </param>
         /// <param name="fractionalCount"> The count of fractional after the decimal point. </param>
+        /// <exception cref="ArgumentOutOfRangeException"> If fractional count is greater than 15. </exception>
         /// <returns>
         /// The RankineConverter <see langword="double"/> result.
         /// </returns>
@@ -320,6 +342,7 @@
         /// </summary>
         /// <param name="input"> The value to be converted. </param>
         /// <param name="fractionalCount"> The count of fractional after the decimal point. </param>
+        /// <exception cref="ArgumentOutOfRangeException"> If fractional count is greater than 15. </exception>
         /// <returns>
         /// The RankineConverter <see langword="double"/> result.
         /// </returns>
@@ -333,6 +356,7 @@
         /// </summary>
         /// <param name="input"> The value to be converted. </param>
         /// <param name="fractionalCount"> The count of fractional after the decimal point. </param>
+        /// <exception cref="ArgumentOutOfRangeException"> If fractional count is greater than 15. </exception>
         /// <returns>
         /// The RankineConverter <see langword="double"/> result.
         /// </returns>
@@ -346,6 +370,7 @@
         /// </summary>
         /// <param name="input"> The value to be converted. </param>
         /// <param name="fractionalCount"> The count of fractional after the decimal point. </param>
+        /// <exception cref="ArgumentOutOfRangeException"> If fractional count is greater than 15. </exception>
         /// <returns>
         /// The RankineConverter <see langword="double"/> result.
         /// </returns>
@@ -361,6 +386,7 @@
         /// <param name="input"> The value to be converted. </param>
         /// <param name="fractionalCount"> The count of fractional after the decimal point. </param>
         /// <exception cref="ArgumentException"> The TInput type is not a valid type for this method. </exception>
+        /// <exception cref="ArgumentOutOfRangeException"> If fractional count is greater than 15. </exception>
         /// <returns>
         /// The result of the conversion.
         /// </returns>

--- a/src/Converter.Temperature/Extensions/To/ToDoubleExtensions.cs
+++ b/src/Converter.Temperature/Extensions/To/ToDoubleExtensions.cs
@@ -24,7 +24,7 @@
         /// </returns>
         public static double ToCelsius(this CelsiusDouble input, int fractionalCount = -1)
         {
-            return DoubleRounder(CelsiusConverter.CelsiusToCelsius(input.Temperature), fractionalCount);
+            return Rounder(CelsiusConverter.CelsiusToCelsius(input.Temperature), fractionalCount);
         }
 
         /// <summary>
@@ -38,7 +38,7 @@
         /// </returns>
         public static double ToCelsius(this FahrenheitDouble input, int fractionalCount = -1)
         {
-            return DoubleRounder(FahrenheitConverter.FahrenheitToCelsius(input.Temperature), fractionalCount);
+            return Rounder(FahrenheitConverter.FahrenheitToCelsius(input.Temperature), fractionalCount);
         }
 
         /// <summary>
@@ -52,7 +52,7 @@
         /// </returns>
         public static double ToCelsius(this GasDouble input, int fractionalCount = -1)
         {
-            return DoubleRounder(GasConverter.GasToCelsius(input.Temperature), fractionalCount);
+            return Rounder(GasConverter.GasToCelsius(input.Temperature), fractionalCount);
         }
 
         /// <summary>
@@ -65,7 +65,7 @@
         /// </returns>
         public static double ToCelsius(this KelvinDouble input, int fractionalCount = -1)
         {
-            return DoubleRounder(KelvinConverter.KelvinToCelsius(input.Temperature), fractionalCount);
+            return Rounder(KelvinConverter.KelvinToCelsius(input.Temperature), fractionalCount);
         }
 
         /// <summary>
@@ -78,7 +78,7 @@
         /// </returns>
         public static double ToCelsius(this RankineDouble input, int fractionalCount = -1)
         {
-            return DoubleRounder(RankineConverter.RankineToCelsius(input.Temperature), fractionalCount);
+            return Rounder(RankineConverter.RankineToCelsius(input.Temperature), fractionalCount);
         }
 
         /// <summary>
@@ -92,7 +92,7 @@
         /// </returns>
         public static double ToFahrenheit(this CelsiusDouble input, int fractionalCount = -1)
         {
-            return DoubleRounder(CelsiusConverter.CelsiusToFahrenheit(input.Temperature), fractionalCount);
+            return Rounder(CelsiusConverter.CelsiusToFahrenheit(input.Temperature), fractionalCount);
         }
 
         /// <summary>
@@ -105,7 +105,7 @@
         /// </returns>
         public static double ToFahrenheit(this FahrenheitDouble input, int fractionalCount = -1)
         {
-            return DoubleRounder(FahrenheitConverter.FahrenheitToFahrenheit(input.Temperature), fractionalCount);
+            return Rounder(FahrenheitConverter.FahrenheitToFahrenheit(input.Temperature), fractionalCount);
         }
 
         /// <summary>
@@ -119,7 +119,7 @@
         /// </returns>
         public static double ToFahrenheit(this GasDouble input, int fractionalCount = -1)
         {
-            return DoubleRounder(GasConverter.GasToFahrenheit(input.Temperature), fractionalCount);
+            return Rounder(GasConverter.GasToFahrenheit(input.Temperature), fractionalCount);
         }
 
         /// <summary>
@@ -133,7 +133,7 @@
         /// </returns>
         public static double ToFahrenheit(this KelvinDouble input, int fractionalCount = -1)
         {
-            return DoubleRounder(KelvinConverter.KelvinToFahrenheit(input.Temperature), fractionalCount);
+            return Rounder(KelvinConverter.KelvinToFahrenheit(input.Temperature), fractionalCount);
         }
 
         /// <summary>
@@ -147,7 +147,7 @@
         /// </returns>
         public static double ToFahrenheit(this RankineDouble input, int fractionalCount = -1)
         {
-            return DoubleRounder(RankineConverter.RankineToFahrenheit(input.Temperature), fractionalCount);
+            return Rounder(RankineConverter.RankineToFahrenheit(input.Temperature), fractionalCount);
         }
 
         /// <summary>
@@ -161,7 +161,7 @@
         /// </returns>
         public static double ToGas(this CelsiusDouble input, int fractionalCount = -1)
         {
-            return DoubleRounder(CelsiusConverter.CelsiusToGas(input.Temperature), fractionalCount);
+            return Rounder(CelsiusConverter.CelsiusToGas(input.Temperature), fractionalCount);
         }
 
         /// <summary>
@@ -175,7 +175,7 @@
         /// </returns>
         public static double ToGas(this FahrenheitDouble input, int fractionalCount = -1)
         {
-            return DoubleRounder(FahrenheitConverter.FahrenheitToGas(input.Temperature), fractionalCount);
+            return Rounder(FahrenheitConverter.FahrenheitToGas(input.Temperature), fractionalCount);
         }
 
         /// <summary>
@@ -189,7 +189,7 @@
         /// </returns>
         public static double ToGas(this GasDouble input, int fractionalCount = -1)
         {
-            return DoubleRounder(GasConverter.GasToGas(input.Temperature), fractionalCount);
+            return Rounder(GasConverter.GasToGas(input.Temperature), fractionalCount);
         }
 
         /// <summary>
@@ -203,7 +203,7 @@
         /// </returns>
         public static double ToGas(this KelvinDouble input, int fractionalCount = -1)
         {
-            return DoubleRounder(KelvinConverter.KelvinToGas(input.Temperature), fractionalCount);
+            return Rounder(KelvinConverter.KelvinToGas(input.Temperature), fractionalCount);
         }
 
         /// <summary>
@@ -217,7 +217,7 @@
         /// </returns>
         public static double ToGas(this RankineDouble input, int fractionalCount = -1)
         {
-            return DoubleRounder(RankineConverter.RankineToGas(input.Temperature), fractionalCount);
+            return Rounder(RankineConverter.RankineToGas(input.Temperature), fractionalCount);
         }
 
         /// <summary>
@@ -231,7 +231,7 @@
         /// </returns>
         public static double ToKelvin(this CelsiusDouble input, int fractionalCount = -1)
         {
-            return DoubleRounder(CelsiusConverter.CelsiusToKelvin(input.Temperature), fractionalCount);
+            return Rounder(CelsiusConverter.CelsiusToKelvin(input.Temperature), fractionalCount);
         }
 
         /// <summary>
@@ -245,7 +245,7 @@
         /// </returns>
         public static double ToKelvin(this FahrenheitDouble input, int fractionalCount = -1)
         {
-            return DoubleRounder(FahrenheitConverter.FahrenheitToKelvin(input.Temperature), fractionalCount);
+            return Rounder(FahrenheitConverter.FahrenheitToKelvin(input.Temperature), fractionalCount);
         }
 
         /// <summary>
@@ -259,7 +259,7 @@
         /// </returns>
         public static double ToKelvin(this GasDouble input, int fractionalCount = -1)
         {
-            return DoubleRounder(GasConverter.GasToKelvin(input.Temperature), fractionalCount);
+            return Rounder(GasConverter.GasToKelvin(input.Temperature), fractionalCount);
         }
 
         /// <summary>
@@ -272,7 +272,7 @@
         /// </returns>
         public static double ToKelvin(this KelvinDouble input, int fractionalCount = -1)
         {
-            return DoubleRounder(KelvinConverter.KelvinToKelvin(input.Temperature), fractionalCount);
+            return Rounder(KelvinConverter.KelvinToKelvin(input.Temperature), fractionalCount);
         }
 
         /// <summary>
@@ -286,7 +286,7 @@
         /// </returns>
         public static double ToKelvin(this RankineDouble input, int fractionalCount = -1)
         {
-            return DoubleRounder(RankineConverter.RankineToKelvin(input.Temperature), fractionalCount);
+            return Rounder(RankineConverter.RankineToKelvin(input.Temperature), fractionalCount);
         }
 
         /// <summary>
@@ -299,7 +299,7 @@
         /// </returns>
         public static double ToRankine(this CelsiusDouble input, int fractionalCount = -1)
         {
-            return DoubleRounder(CelsiusConverter.CelsiusToRankine(input.Temperature), fractionalCount);
+            return Rounder(CelsiusConverter.CelsiusToRankine(input.Temperature), fractionalCount);
         }
 
         /// <summary>
@@ -312,7 +312,7 @@
         /// </returns>
         public static double ToRankine(this FahrenheitDouble input, int fractionalCount = -1)
         {
-            return DoubleRounder(FahrenheitConverter.FahrenheitToRankine(input.Temperature), fractionalCount);
+            return Rounder(FahrenheitConverter.FahrenheitToRankine(input.Temperature), fractionalCount);
         }
 
         /// <summary>
@@ -325,7 +325,7 @@
         /// </returns>
         public static double ToRankine(this GasDouble input, int fractionalCount = -1)
         {
-            return DoubleRounder(GasConverter.GasToRankine(input.Temperature), fractionalCount);
+            return Rounder(GasConverter.GasToRankine(input.Temperature), fractionalCount);
         }
 
         /// <summary>
@@ -338,7 +338,7 @@
         /// </returns>
         public static double ToRankine(this KelvinDouble input, int fractionalCount = -1)
         {
-            return DoubleRounder(KelvinConverter.KelvinToRankine(input.Temperature), fractionalCount);
+            return Rounder(KelvinConverter.KelvinToRankine(input.Temperature), fractionalCount);
         }
 
         /// <summary>
@@ -351,7 +351,7 @@
         /// </returns>
         public static double ToRankine(this RankineDouble input, int fractionalCount = -1)
         {
-            return DoubleRounder(RankineConverter.RankineToRankine(input.Temperature), fractionalCount);
+            return Rounder(RankineConverter.RankineToRankine(input.Temperature), fractionalCount);
         }
 
         /// <summary>
@@ -369,41 +369,38 @@
         {
             return typeof(TInput).Name switch
             {
-                nameof(Celsius) when input is CelsiusDouble castInput => DoubleRounder(CelsiusConverter.CelsiusToCelsius(castInput.Temperature), fractionalCount),
-                nameof(Celsius) when input is FahrenheitDouble castInput => DoubleRounder(FahrenheitConverter.FahrenheitToCelsius(castInput.Temperature), fractionalCount),
-                nameof(Celsius) when input is KelvinDouble castInput => DoubleRounder(KelvinConverter.KelvinToCelsius(castInput.Temperature), fractionalCount),
-                nameof(Celsius) when input is GasDouble castInput => DoubleRounder(GasConverter.GasToCelsius(castInput.Temperature), fractionalCount),
-                nameof(Celsius) when input is RankineDouble castInput => DoubleRounder(RankineConverter.RankineToCelsius(castInput.Temperature), fractionalCount),
-                nameof(Fahrenheit) when input is CelsiusDouble castInput => DoubleRounder(CelsiusConverter.CelsiusToFahrenheit(castInput.Temperature), fractionalCount),
-                nameof(Fahrenheit) when input is FahrenheitDouble castInput => DoubleRounder(FahrenheitConverter.FahrenheitToFahrenheit(castInput.Temperature), fractionalCount),
-                nameof(Fahrenheit) when input is KelvinDouble castInput => DoubleRounder(KelvinConverter.KelvinToFahrenheit(castInput.Temperature), fractionalCount),
-                nameof(Fahrenheit) when input is GasDouble castInput => DoubleRounder(GasConverter.GasToFahrenheit(castInput.Temperature), fractionalCount),
-                nameof(Fahrenheit) when input is RankineDouble castInput => DoubleRounder(RankineConverter.RankineToFahrenheit(castInput.Temperature), fractionalCount),
-                nameof(Kelvin) when input is CelsiusDouble castInput => DoubleRounder(CelsiusConverter.CelsiusToKelvin(castInput.Temperature), fractionalCount),
-                nameof(Kelvin) when input is FahrenheitDouble castInput => DoubleRounder(FahrenheitConverter.FahrenheitToKelvin(castInput.Temperature), fractionalCount),
-                nameof(Kelvin) when input is KelvinDouble castInput => DoubleRounder(KelvinConverter.KelvinToKelvin(castInput.Temperature), fractionalCount),
-                nameof(Kelvin) when input is GasDouble castInput => DoubleRounder(GasConverter.GasToKelvin(castInput.Temperature), fractionalCount),
-                nameof(Kelvin) when input is RankineDouble castInput => DoubleRounder(RankineConverter.RankineToKelvin(castInput.Temperature), fractionalCount),
-                nameof(Gas) when input is CelsiusDouble castInput => DoubleRounder(CelsiusConverter.CelsiusToGas(castInput.Temperature), fractionalCount),
-                nameof(Gas) when input is FahrenheitDouble castInput => DoubleRounder(FahrenheitConverter.FahrenheitToGas(castInput.Temperature), fractionalCount),
-                nameof(Gas) when input is KelvinDouble castInput => DoubleRounder(KelvinConverter.KelvinToGas(castInput.Temperature), fractionalCount),
-                nameof(Gas) when input is GasDouble castInput => DoubleRounder(GasConverter.GasToGas(castInput.Temperature), fractionalCount),
-                nameof(Gas) when input is RankineDouble castInput => DoubleRounder(RankineConverter.RankineToGas(castInput.Temperature), fractionalCount),
-                nameof(Rankine) when input is CelsiusDouble castInput => DoubleRounder(CelsiusConverter.CelsiusToRankine(castInput.Temperature), fractionalCount),
-                nameof(Rankine) when input is FahrenheitDouble castInput => DoubleRounder(FahrenheitConverter.FahrenheitToRankine(castInput.Temperature), fractionalCount),
-                nameof(Rankine) when input is KelvinDouble castInput => DoubleRounder(KelvinConverter.KelvinToRankine(castInput.Temperature), fractionalCount),
-                nameof(Rankine) when input is GasDouble castInput => DoubleRounder(GasConverter.GasToRankine(castInput.Temperature), fractionalCount),
-                nameof(Rankine) when input is RankineDouble castInput => DoubleRounder(RankineConverter.RankineToRankine(castInput.Temperature), fractionalCount),
+                nameof(Celsius) when input is CelsiusDouble castInput => Rounder(CelsiusConverter.CelsiusToCelsius(castInput.Temperature), fractionalCount),
+                nameof(Celsius) when input is FahrenheitDouble castInput => Rounder(FahrenheitConverter.FahrenheitToCelsius(castInput.Temperature), fractionalCount),
+                nameof(Celsius) when input is KelvinDouble castInput => Rounder(KelvinConverter.KelvinToCelsius(castInput.Temperature), fractionalCount),
+                nameof(Celsius) when input is GasDouble castInput => Rounder(GasConverter.GasToCelsius(castInput.Temperature), fractionalCount),
+                nameof(Celsius) when input is RankineDouble castInput => Rounder(RankineConverter.RankineToCelsius(castInput.Temperature), fractionalCount),
+                nameof(Fahrenheit) when input is CelsiusDouble castInput => Rounder(CelsiusConverter.CelsiusToFahrenheit(castInput.Temperature), fractionalCount),
+                nameof(Fahrenheit) when input is FahrenheitDouble castInput => Rounder(FahrenheitConverter.FahrenheitToFahrenheit(castInput.Temperature), fractionalCount),
+                nameof(Fahrenheit) when input is KelvinDouble castInput => Rounder(KelvinConverter.KelvinToFahrenheit(castInput.Temperature), fractionalCount),
+                nameof(Fahrenheit) when input is GasDouble castInput => Rounder(GasConverter.GasToFahrenheit(castInput.Temperature), fractionalCount),
+                nameof(Fahrenheit) when input is RankineDouble castInput => Rounder(RankineConverter.RankineToFahrenheit(castInput.Temperature), fractionalCount),
+                nameof(Kelvin) when input is CelsiusDouble castInput => Rounder(CelsiusConverter.CelsiusToKelvin(castInput.Temperature), fractionalCount),
+                nameof(Kelvin) when input is FahrenheitDouble castInput => Rounder(FahrenheitConverter.FahrenheitToKelvin(castInput.Temperature), fractionalCount),
+                nameof(Kelvin) when input is KelvinDouble castInput => Rounder(KelvinConverter.KelvinToKelvin(castInput.Temperature), fractionalCount),
+                nameof(Kelvin) when input is GasDouble castInput => Rounder(GasConverter.GasToKelvin(castInput.Temperature), fractionalCount),
+                nameof(Kelvin) when input is RankineDouble castInput => Rounder(RankineConverter.RankineToKelvin(castInput.Temperature), fractionalCount),
+                nameof(Gas) when input is CelsiusDouble castInput => Rounder(CelsiusConverter.CelsiusToGas(castInput.Temperature), fractionalCount),
+                nameof(Gas) when input is FahrenheitDouble castInput => Rounder(FahrenheitConverter.FahrenheitToGas(castInput.Temperature), fractionalCount),
+                nameof(Gas) when input is KelvinDouble castInput => Rounder(KelvinConverter.KelvinToGas(castInput.Temperature), fractionalCount),
+                nameof(Gas) when input is GasDouble castInput => Rounder(GasConverter.GasToGas(castInput.Temperature), fractionalCount),
+                nameof(Gas) when input is RankineDouble castInput => Rounder(RankineConverter.RankineToGas(castInput.Temperature), fractionalCount),
+                nameof(Rankine) when input is CelsiusDouble castInput => Rounder(CelsiusConverter.CelsiusToRankine(castInput.Temperature), fractionalCount),
+                nameof(Rankine) when input is FahrenheitDouble castInput => Rounder(FahrenheitConverter.FahrenheitToRankine(castInput.Temperature), fractionalCount),
+                nameof(Rankine) when input is KelvinDouble castInput => Rounder(KelvinConverter.KelvinToRankine(castInput.Temperature), fractionalCount),
+                nameof(Rankine) when input is GasDouble castInput => Rounder(GasConverter.GasToRankine(castInput.Temperature), fractionalCount),
+                nameof(Rankine) when input is RankineDouble castInput => Rounder(RankineConverter.RankineToRankine(castInput.Temperature), fractionalCount),
                 _ => throw new ArgumentException($"Invalid type: {typeof(TInput).Name}")
             };
         }
 
-        private static double DoubleRounder(double input, int fractionalCount = -1)
+        private static double Rounder(double input, int fractionalCount = -1)
         {
-            if (fractionalCount < 0)
-                return input;
-
-            return Math.Round(input, fractionalCount);
+            return fractionalCount < 0 ? input : Math.Round(input, fractionalCount);
         }
     }
 }

--- a/src/Converter.Temperature/Extensions/To/ToDoubleExtensions.cs
+++ b/src/Converter.Temperature/Extensions/To/ToDoubleExtensions.cs
@@ -18,315 +18,340 @@
         /// Converts the Celsius <paramref name="input"/> to Celsius
         /// </summary>
         /// <param name="input"> The value to be converted. </param>
+        /// <param name="fractionalCount"> The count of fractional after the decimal point. </param>
         /// <returns>
         /// The Celsius <see langword="double"/> result.
         /// </returns>
-        public static double ToCelsius(this CelsiusDouble input)
+        public static double ToCelsius(this CelsiusDouble input, int fractionalCount = -1)
         {
-            return CelsiusConverter.CelsiusToCelsius(input.Temperature);
+            return DoubleRounder(CelsiusConverter.CelsiusToCelsius(input.Temperature), fractionalCount);
         }
 
         /// <summary>
         /// Converts the FahrenheitConverter <paramref name="input"/> to Celsius
         /// </summary>
         /// <param name="input"> The value to be converted. </param>
+        /// <param name="fractionalCount"> The count of fractional after the decimal point. </param>
         /// <exception cref="T:System.ArgumentOutOfRangeException">If calculated value is beyond the limits of the type.</exception>
         /// <returns>
         /// The Celsius <see langword="double"/> result.
         /// </returns>
-        public static double ToCelsius(this FahrenheitDouble input)
+        public static double ToCelsius(this FahrenheitDouble input, int fractionalCount = -1)
         {
-            return FahrenheitConverter.FahrenheitToCelsius(input.Temperature);
+            return DoubleRounder(FahrenheitConverter.FahrenheitToCelsius(input.Temperature), fractionalCount);
         }
 
         /// <summary>
         /// Converts the GasConverter <paramref name="input"/> to Celsius
         /// </summary>
         /// <param name="input"> The value to be converted. </param>
+        /// <param name="fractionalCount"> The count of fractional after the decimal point. </param>
         /// <exception cref="T:System.ArgumentOutOfRangeException">Temp too low or too high for gas mark!</exception>
         /// <returns>
         /// The Celsius <see langword="double"/> result.
         /// </returns>
-        public static double ToCelsius(this GasDouble input)
+        public static double ToCelsius(this GasDouble input, int fractionalCount = -1)
         {
-            return GasConverter.GasToCelsius(input.Temperature);
+            return DoubleRounder(GasConverter.GasToCelsius(input.Temperature), fractionalCount);
         }
 
         /// <summary>
         /// Converts the KelvinConverter <paramref name="input"/> to Celsius
         /// </summary>
         /// <param name="input"> The value to be converted. </param>
+        /// <param name="fractionalCount"> The count of fractional after the decimal point. </param>
         /// <returns>
         /// The Celsius <see langword="double"/> result.
         /// </returns>
-        public static double ToCelsius(this KelvinDouble input)
+        public static double ToCelsius(this KelvinDouble input, int fractionalCount = -1)
         {
-            return KelvinConverter.KelvinToCelsius(input.Temperature);
+            return DoubleRounder(KelvinConverter.KelvinToCelsius(input.Temperature), fractionalCount);
         }
 
         /// <summary>
         /// Converts the RankineConverter <paramref name="input"/> to Celsius
         /// </summary>
         /// <param name="input"> The value to be converted. </param>
+        /// <param name="fractionalCount"> The count of fractional after the decimal point. </param>
         /// <returns>
         /// The Celsius <see langword="double"/> result.
         /// </returns>
-        public static double ToCelsius(this RankineDouble input)
+        public static double ToCelsius(this RankineDouble input, int fractionalCount = -1)
         {
-            return RankineConverter.RankineToCelsius(input.Temperature);
+            return DoubleRounder(RankineConverter.RankineToCelsius(input.Temperature), fractionalCount);
         }
 
         /// <summary>
         /// Converts the Celsius <paramref name="input"/> to FahrenheitConverter
         /// </summary>
         /// <param name="input"> The value to be converted. </param>
+        /// <param name="fractionalCount"> The count of fractional after the decimal point. </param>
         /// <exception cref="T:System.ArgumentOutOfRangeException">If calculated value is beyond the limits of the type.</exception>
         /// <returns>
         /// The FahrenheitConverter <see langword="double"/> result.
         /// </returns>
-        public static double ToFahrenheit(this CelsiusDouble input)
+        public static double ToFahrenheit(this CelsiusDouble input, int fractionalCount = -1)
         {
-            return CelsiusConverter.CelsiusToFahrenheit(input.Temperature);
+            return DoubleRounder(CelsiusConverter.CelsiusToFahrenheit(input.Temperature), fractionalCount);
         }
 
         /// <summary>
         /// Converts the FahrenheitConverter <paramref name="input"/> to FahrenheitConverter
         /// </summary>
         /// <param name="input"> The value to be converted. </param>
+        /// <param name="fractionalCount"> The count of fractional after the decimal point. </param>
         /// <returns>
         /// The FahrenheitConverter <see langword="double"/> result.
         /// </returns>
-        public static double ToFahrenheit(this FahrenheitDouble input)
+        public static double ToFahrenheit(this FahrenheitDouble input, int fractionalCount = -1)
         {
-            return FahrenheitConverter.FahrenheitToFahrenheit(input.Temperature);
+            return DoubleRounder(FahrenheitConverter.FahrenheitToFahrenheit(input.Temperature), fractionalCount);
         }
 
         /// <summary>
         /// Converts the GasConverter <paramref name="input"/> to FahrenheitConverter
         /// </summary>
         /// <param name="input"> The value to be converted. </param>
+        /// <param name="fractionalCount"> The count of fractional after the decimal point. </param>
         /// <exception cref="T:System.ArgumentOutOfRangeException">Temp too low or too high for gas mark!</exception>
         /// <returns>
         /// The FahrenheitConverter <see langword="double"/> result.
         /// </returns>
-        public static double ToFahrenheit(this GasDouble input)
+        public static double ToFahrenheit(this GasDouble input, int fractionalCount = -1)
         {
-            return GasConverter.GasToFahrenheit(input.Temperature);
+            return DoubleRounder(GasConverter.GasToFahrenheit(input.Temperature), fractionalCount);
         }
 
         /// <summary>
         /// Converts the KelvinConverter <paramref name="input"/> to FahrenheitConverter
         /// </summary>
         /// <param name="input"> The value to be converted. </param>
+        /// <param name="fractionalCount"> The count of fractional after the decimal point. </param>
         /// <exception cref="T:System.ArgumentOutOfRangeException">If calculated value is beyond the limits of the type.</exception>
         /// <returns>
         /// The FahrenheitConverter <see langword="double"/> result.
         /// </returns>
-        public static double ToFahrenheit(this KelvinDouble input)
+        public static double ToFahrenheit(this KelvinDouble input, int fractionalCount = -1)
         {
-            return KelvinConverter.KelvinToFahrenheit(input.Temperature);
+            return DoubleRounder(KelvinConverter.KelvinToFahrenheit(input.Temperature), fractionalCount);
         }
 
         /// <summary>
         /// Converts the RankineConverter <paramref name="input"/> to FahrenheitConverter
         /// </summary>
         /// <param name="input"> The value to be converted. </param>
+        /// <param name="fractionalCount"> The count of fractional after the decimal point. </param>
         /// <exception cref="T:System.ArgumentOutOfRangeException">If calculated value is beyond the limits of the type.</exception>
         /// <returns>
         /// The FahrenheitConverter <see langword="double"/> result.
         /// </returns>
-        public static double ToFahrenheit(this RankineDouble input)
+        public static double ToFahrenheit(this RankineDouble input, int fractionalCount = -1)
         {
-            return RankineConverter.RankineToFahrenheit(input.Temperature);
+            return DoubleRounder(RankineConverter.RankineToFahrenheit(input.Temperature), fractionalCount);
         }
 
         /// <summary>
         /// Converts the Celsius <paramref name="input"/> to GasConverter
         /// </summary>
         /// <param name="input"> The value to be converted. </param>
+        /// <param name="fractionalCount"> The count of fractional after the decimal point. </param>
         /// <exception cref="T:System.ArgumentOutOfRangeException">Temp too low or too high for gas mark!</exception>
         /// <returns>
         /// The GasConverter <see langword="double"/> result.
         /// </returns>
-        public static double ToGas(this CelsiusDouble input)
+        public static double ToGas(this CelsiusDouble input, int fractionalCount = -1)
         {
-            return CelsiusConverter.CelsiusToGas(input.Temperature);
+            return DoubleRounder(CelsiusConverter.CelsiusToGas(input.Temperature), fractionalCount);
         }
 
         /// <summary>
         /// Converts the FahrenheitConverter <paramref name="input"/> to GasConverter
         /// </summary>
         /// <param name="input"> The value to be converted. </param>
+        /// <param name="fractionalCount"> The count of fractional after the decimal point. </param>
         /// <exception cref="T:System.ArgumentOutOfRangeException">Temp too low or too high for gas mark!</exception>
         /// <returns>
         /// The GasConverter <see langword="double"/> result.
         /// </returns>
-        public static double ToGas(this FahrenheitDouble input)
+        public static double ToGas(this FahrenheitDouble input, int fractionalCount = -1)
         {
-            return FahrenheitConverter.FahrenheitToGas(input.Temperature);
+            return DoubleRounder(FahrenheitConverter.FahrenheitToGas(input.Temperature), fractionalCount);
         }
 
         /// <summary>
         /// Converts the GasConverter <paramref name="input"/> to GasConverter
         /// </summary>
         /// <param name="input"> The value to be converted. </param>
+        /// <param name="fractionalCount"> The count of fractional after the decimal point. </param>
         /// <exception cref="T:System.ArgumentOutOfRangeException">Temp too low or too high for gas mark!</exception>
         /// <returns>
         /// The GasConverter <see langword="double"/> result.
         /// </returns>
-        public static double ToGas(this GasDouble input)
+        public static double ToGas(this GasDouble input, int fractionalCount = -1)
         {
-            return GasConverter.GasToGas(input.Temperature);
+            return DoubleRounder(GasConverter.GasToGas(input.Temperature), fractionalCount);
         }
 
         /// <summary>
         /// Converts the KelvinConverter <paramref name="input"/> to GasConverter
         /// </summary>
         /// <param name="input"> The value to be converted. </param>
+        /// <param name="fractionalCount"> The count of fractional after the decimal point. </param>
         /// <exception cref="T:System.ArgumentOutOfRangeException">Temp too low or too high for gas mark!</exception>
         /// <returns>
         /// The GasConverter <see langword="double"/> result.
         /// </returns>
-        public static double ToGas(this KelvinDouble input)
+        public static double ToGas(this KelvinDouble input, int fractionalCount = -1)
         {
-            return KelvinConverter.KelvinToGas(input.Temperature);
+            return DoubleRounder(KelvinConverter.KelvinToGas(input.Temperature), fractionalCount);
         }
 
         /// <summary>
         /// Converts the RankineConverter <paramref name="input"/> to GasConverter
         /// </summary>
         /// <param name="input"> The value to be converted. </param>
+        /// <param name="fractionalCount"> The count of fractional after the decimal point. </param>
         /// <exception cref="T:System.ArgumentOutOfRangeException">Temp too low or too high for gas mark!</exception>
         /// <returns>
         /// The GasConverter <see langword="double"/> result.
         /// </returns>
-        public static double ToGas(this RankineDouble input)
+        public static double ToGas(this RankineDouble input, int fractionalCount = -1)
         {
-            return RankineConverter.RankineToGas(input.Temperature);
+            return DoubleRounder(RankineConverter.RankineToGas(input.Temperature), fractionalCount);
         }
 
         /// <summary>
         /// Converts the Celsius <paramref name="input"/> to KelvinConverter
         /// </summary>
         /// <param name="input"> The value to be converted. </param>
+        /// <param name="fractionalCount"> The count of fractional after the decimal point. </param>
         /// <exception cref="T:System.ArgumentOutOfRangeException">If calculated value is beyond the limits of the type.</exception>
         /// <returns>
         /// The KelvinConverter <see langword="double"/> result.
         /// </returns>
-        public static double ToKelvin(this CelsiusDouble input)
+        public static double ToKelvin(this CelsiusDouble input, int fractionalCount = -1)
         {
-            return CelsiusConverter.CelsiusToKelvin(input.Temperature);
+            return DoubleRounder(CelsiusConverter.CelsiusToKelvin(input.Temperature), fractionalCount);
         }
 
         /// <summary>
         /// Converts the FahrenheitConverter <paramref name="input"/> to KelvinConverter
         /// </summary>
         /// <param name="input"> The value to be converted. </param>
+        /// <param name="fractionalCount"> The count of fractional after the decimal point. </param>
         /// <exception cref="T:System.ArgumentOutOfRangeException">If calculated value is beyond the limits of the type.</exception>
         /// <returns>
         /// The KelvinConverter <see langword="double"/> result.
         /// </returns>
-        public static double ToKelvin(this FahrenheitDouble input)
+        public static double ToKelvin(this FahrenheitDouble input, int fractionalCount = -1)
         {
-            return FahrenheitConverter.FahrenheitToKelvin(input.Temperature);
+            return DoubleRounder(FahrenheitConverter.FahrenheitToKelvin(input.Temperature), fractionalCount);
         }
 
         /// <summary>
         /// Converts the GasConverter <paramref name="input"/> to KelvinConverter
         /// </summary>
         /// <param name="input"> The value to be converted. </param>
+        /// <param name="fractionalCount"> The count of fractional after the decimal point. </param>
         /// <exception cref="T:System.ArgumentOutOfRangeException">Temp too low or too high for gas mark!</exception>
         /// <returns>
         /// The KelvinConverter <see langword="double"/> result.
         /// </returns>
-        public static double ToKelvin(this GasDouble input)
+        public static double ToKelvin(this GasDouble input, int fractionalCount = -1)
         {
-            return GasConverter.GasToKelvin(input.Temperature);
+            return DoubleRounder(GasConverter.GasToKelvin(input.Temperature), fractionalCount);
         }
 
         /// <summary>
         /// Converts the KelvinConverter <paramref name="input"/> to KelvinConverter
         /// </summary>
         /// <param name="input"> The value to be converted. </param>
+        /// <param name="fractionalCount"> The count of fractional after the decimal point. </param>
         /// <returns>
         /// The KelvinConverter <see langword="double"/> result.
         /// </returns>
-        public static double ToKelvin(this KelvinDouble input)
+        public static double ToKelvin(this KelvinDouble input, int fractionalCount = -1)
         {
-            return KelvinConverter.KelvinToKelvin(input.Temperature);
+            return DoubleRounder(KelvinConverter.KelvinToKelvin(input.Temperature), fractionalCount);
         }
 
         /// <summary>
         /// Converts the RankineConverter <paramref name="input"/> to KelvinConverter
         /// </summary>
         /// <param name="input"> The value to be converted. </param>
+        /// <param name="fractionalCount"> The count of fractional after the decimal point. </param>
         /// <exception cref="T:System.ArgumentOutOfRangeException">If calculated value is beyond the limits of the type.</exception>
         /// <returns>
         /// The KelvinConverter <see langword="double"/> result.
         /// </returns>
-        public static double ToKelvin(this RankineDouble input)
+        public static double ToKelvin(this RankineDouble input, int fractionalCount = -1)
         {
-            return RankineConverter.RankineToKelvin(input.Temperature);
+            return DoubleRounder(RankineConverter.RankineToKelvin(input.Temperature), fractionalCount);
         }
 
         /// <summary>
         /// Converts the Celsius <paramref name="input"/> to Ranking
         /// </summary>
         /// <param name="input"> The value to be converted. </param>
+        /// <param name="fractionalCount"> The count of fractional after the decimal point. </param>
         /// <returns>
         /// The RankineConverter <see langword="double"/> result.
         /// </returns>
-        public static double ToRankine(this CelsiusDouble input)
+        public static double ToRankine(this CelsiusDouble input, int fractionalCount = -1)
         {
-            return CelsiusConverter.CelsiusToRankine(input.Temperature);
+            return DoubleRounder(CelsiusConverter.CelsiusToRankine(input.Temperature), fractionalCount);
         }
 
         /// <summary>
         /// Converts the FahrenheitConverter <paramref name="input"/> to Ranking
         /// </summary>
         /// <param name="input"> The value to be converted. </param>
+        /// <param name="fractionalCount"> The count of fractional after the decimal point. </param>
         /// <returns>
         /// The RankineConverter <see langword="double"/> result.
         /// </returns>
-        public static double ToRankine(this FahrenheitDouble input)
+        public static double ToRankine(this FahrenheitDouble input, int fractionalCount = -1)
         {
-            return FahrenheitConverter.FahrenheitToRankine(input.Temperature);
+            return DoubleRounder(FahrenheitConverter.FahrenheitToRankine(input.Temperature), fractionalCount);
         }
 
         /// <summary>
         /// Converts the FahrenheitConverter <paramref name="input"/> to Ranking
         /// </summary>
         /// <param name="input"> The value to be converted. </param>
+        /// <param name="fractionalCount"> The count of fractional after the decimal point. </param>
         /// <returns>
         /// The RankineConverter <see langword="double"/> result.
         /// </returns>
-        public static double ToRankine(this GasDouble input)
+        public static double ToRankine(this GasDouble input, int fractionalCount = -1)
         {
-            return GasConverter.GasToRankine(input.Temperature);
+            return DoubleRounder(GasConverter.GasToRankine(input.Temperature), fractionalCount);
         }
 
         /// <summary>
         /// Converts the KelvinConverter <paramref name="input"/> to Ranking
         /// </summary>
         /// <param name="input"> The value to be converted. </param>
+        /// <param name="fractionalCount"> The count of fractional after the decimal point. </param>
         /// <returns>
         /// The RankineConverter <see langword="double"/> result.
         /// </returns>
-        public static double ToRankine(this KelvinDouble input)
+        public static double ToRankine(this KelvinDouble input, int fractionalCount = -1)
         {
-            return KelvinConverter.KelvinToRankine(input.Temperature);
+            return DoubleRounder(KelvinConverter.KelvinToRankine(input.Temperature), fractionalCount);
         }
 
         /// <summary>
         /// Converts the RankineConverter <paramref name="input"/> to Ranking
         /// </summary>
         /// <param name="input"> The value to be converted. </param>
+        /// <param name="fractionalCount"> The count of fractional after the decimal point. </param>
         /// <returns>
         /// The RankineConverter <see langword="double"/> result.
         /// </returns>
-        public static double ToRankine(this RankineDouble input)
+        public static double ToRankine(this RankineDouble input, int fractionalCount = -1)
         {
-            return RankineConverter.RankineToRankine(input.Temperature);
+            return DoubleRounder(RankineConverter.RankineToRankine(input.Temperature), fractionalCount);
         }
 
         /// <summary>
@@ -334,42 +359,51 @@
         /// </summary>
         /// <typeparam name="TInput"> The temperature type to be converted to. </typeparam>
         /// <param name="input"> The value to be converted. </param>
+        /// <param name="fractionalCount"> The count of fractional after the decimal point. </param>
         /// <exception cref="ArgumentException"> The TInput type is not a valid type for this method. </exception>
         /// <returns>
         /// The result of the conversion.
         /// </returns>
-        public static double To<TInput>(this DoubleBase input)
+        public static double To<TInput>(this DoubleBase input, int fractionalCount = -1)
             where TInput : TemperatureBase
         {
             return typeof(TInput).Name switch
             {
-                nameof(Celsius) when input is CelsiusDouble castInput => CelsiusConverter.CelsiusToCelsius(castInput.Temperature),
-                nameof(Celsius) when input is FahrenheitDouble castInput => FahrenheitConverter.FahrenheitToCelsius(castInput.Temperature),
-                nameof(Celsius) when input is KelvinDouble castInput => KelvinConverter.KelvinToCelsius(castInput.Temperature),
-                nameof(Celsius) when input is GasDouble castInput => GasConverter.GasToCelsius(castInput.Temperature),
-                nameof(Celsius) when input is RankineDouble castInput => RankineConverter.RankineToCelsius(castInput.Temperature),
-                nameof(Fahrenheit) when input is CelsiusDouble castInput => CelsiusConverter.CelsiusToFahrenheit(castInput.Temperature),
-                nameof(Fahrenheit) when input is FahrenheitDouble castInput => FahrenheitConverter.FahrenheitToFahrenheit(castInput.Temperature),
-                nameof(Fahrenheit) when input is KelvinDouble castInput => KelvinConverter.KelvinToFahrenheit(castInput.Temperature),
-                nameof(Fahrenheit) when input is GasDouble castInput => GasConverter.GasToFahrenheit(castInput.Temperature),
-                nameof(Fahrenheit) when input is RankineDouble castInput => RankineConverter.RankineToFahrenheit(castInput.Temperature),
-                nameof(Kelvin) when input is CelsiusDouble castInput => CelsiusConverter.CelsiusToKelvin(castInput.Temperature),
-                nameof(Kelvin) when input is FahrenheitDouble castInput => FahrenheitConverter.FahrenheitToKelvin(castInput.Temperature),
-                nameof(Kelvin) when input is KelvinDouble castInput => KelvinConverter.KelvinToKelvin(castInput.Temperature),
-                nameof(Kelvin) when input is GasDouble castInput => GasConverter.GasToKelvin(castInput.Temperature),
-                nameof(Kelvin) when input is RankineDouble castInput => RankineConverter.RankineToKelvin(castInput.Temperature),
-                nameof(Gas) when input is CelsiusDouble castInput => CelsiusConverter.CelsiusToGas(castInput.Temperature),
-                nameof(Gas) when input is FahrenheitDouble castInput => FahrenheitConverter.FahrenheitToGas(castInput.Temperature),
-                nameof(Gas) when input is KelvinDouble castInput => KelvinConverter.KelvinToGas(castInput.Temperature),
-                nameof(Gas) when input is GasDouble castInput => GasConverter.GasToGas(castInput.Temperature),
-                nameof(Gas) when input is RankineDouble castInput => RankineConverter.RankineToGas(castInput.Temperature),
-                nameof(Rankine) when input is CelsiusDouble castInput => CelsiusConverter.CelsiusToRankine(castInput.Temperature),
-                nameof(Rankine) when input is FahrenheitDouble castInput => FahrenheitConverter.FahrenheitToRankine(castInput.Temperature),
-                nameof(Rankine) when input is KelvinDouble castInput => KelvinConverter.KelvinToRankine(castInput.Temperature),
-                nameof(Rankine) when input is GasDouble castInput => GasConverter.GasToRankine(castInput.Temperature),
-                nameof(Rankine) when input is RankineDouble castInput => RankineConverter.RankineToRankine(castInput.Temperature),
+                nameof(Celsius) when input is CelsiusDouble castInput => DoubleRounder(CelsiusConverter.CelsiusToCelsius(castInput.Temperature), fractionalCount),
+                nameof(Celsius) when input is FahrenheitDouble castInput => DoubleRounder(FahrenheitConverter.FahrenheitToCelsius(castInput.Temperature), fractionalCount),
+                nameof(Celsius) when input is KelvinDouble castInput => DoubleRounder(KelvinConverter.KelvinToCelsius(castInput.Temperature), fractionalCount),
+                nameof(Celsius) when input is GasDouble castInput => DoubleRounder(GasConverter.GasToCelsius(castInput.Temperature), fractionalCount),
+                nameof(Celsius) when input is RankineDouble castInput => DoubleRounder(RankineConverter.RankineToCelsius(castInput.Temperature), fractionalCount),
+                nameof(Fahrenheit) when input is CelsiusDouble castInput => DoubleRounder(CelsiusConverter.CelsiusToFahrenheit(castInput.Temperature), fractionalCount),
+                nameof(Fahrenheit) when input is FahrenheitDouble castInput => DoubleRounder(FahrenheitConverter.FahrenheitToFahrenheit(castInput.Temperature), fractionalCount),
+                nameof(Fahrenheit) when input is KelvinDouble castInput => DoubleRounder(KelvinConverter.KelvinToFahrenheit(castInput.Temperature), fractionalCount),
+                nameof(Fahrenheit) when input is GasDouble castInput => DoubleRounder(GasConverter.GasToFahrenheit(castInput.Temperature), fractionalCount),
+                nameof(Fahrenheit) when input is RankineDouble castInput => DoubleRounder(RankineConverter.RankineToFahrenheit(castInput.Temperature), fractionalCount),
+                nameof(Kelvin) when input is CelsiusDouble castInput => DoubleRounder(CelsiusConverter.CelsiusToKelvin(castInput.Temperature), fractionalCount),
+                nameof(Kelvin) when input is FahrenheitDouble castInput => DoubleRounder(FahrenheitConverter.FahrenheitToKelvin(castInput.Temperature), fractionalCount),
+                nameof(Kelvin) when input is KelvinDouble castInput => DoubleRounder(KelvinConverter.KelvinToKelvin(castInput.Temperature), fractionalCount),
+                nameof(Kelvin) when input is GasDouble castInput => DoubleRounder(GasConverter.GasToKelvin(castInput.Temperature), fractionalCount),
+                nameof(Kelvin) when input is RankineDouble castInput => DoubleRounder(RankineConverter.RankineToKelvin(castInput.Temperature), fractionalCount),
+                nameof(Gas) when input is CelsiusDouble castInput => DoubleRounder(CelsiusConverter.CelsiusToGas(castInput.Temperature), fractionalCount),
+                nameof(Gas) when input is FahrenheitDouble castInput => DoubleRounder(FahrenheitConverter.FahrenheitToGas(castInput.Temperature), fractionalCount),
+                nameof(Gas) when input is KelvinDouble castInput => DoubleRounder(KelvinConverter.KelvinToGas(castInput.Temperature), fractionalCount),
+                nameof(Gas) when input is GasDouble castInput => DoubleRounder(GasConverter.GasToGas(castInput.Temperature), fractionalCount),
+                nameof(Gas) when input is RankineDouble castInput => DoubleRounder(RankineConverter.RankineToGas(castInput.Temperature), fractionalCount),
+                nameof(Rankine) when input is CelsiusDouble castInput => DoubleRounder(CelsiusConverter.CelsiusToRankine(castInput.Temperature), fractionalCount),
+                nameof(Rankine) when input is FahrenheitDouble castInput => DoubleRounder(FahrenheitConverter.FahrenheitToRankine(castInput.Temperature), fractionalCount),
+                nameof(Rankine) when input is KelvinDouble castInput => DoubleRounder(KelvinConverter.KelvinToRankine(castInput.Temperature), fractionalCount),
+                nameof(Rankine) when input is GasDouble castInput => DoubleRounder(GasConverter.GasToRankine(castInput.Temperature), fractionalCount),
+                nameof(Rankine) when input is RankineDouble castInput => DoubleRounder(RankineConverter.RankineToRankine(castInput.Temperature), fractionalCount),
                 _ => throw new ArgumentException($"Invalid type: {typeof(TInput).Name}")
             };
+        }
+
+        private static double DoubleRounder(double input, int fractionalCount = -1)
+        {
+            if (fractionalCount < 0)
+                return input;
+
+            return Math.Round(input, fractionalCount);
         }
     }
 }

--- a/src/Converter.Temperature/Extensions/To/ToFloatExtensions.cs
+++ b/src/Converter.Temperature/Extensions/To/ToFloatExtensions.cs
@@ -19,319 +19,344 @@
         /// Converts the Celsius <paramref name="input"/> to Celsius
         /// </summary>
         /// <param name="input"> The value to be converted. </param>
+        /// <param name="fractionalCount"> The count of fractional after the decimal point. </param>
         /// <returns>
         /// The Celsius <see langword="float"/> result.
         /// </returns>
-        public static float ToCelsius(this CelsiusFloat input)
+        public static float ToCelsius(this CelsiusFloat input, int fractionalCount = -1)
         {
-            return FloatParser(CelsiusConverter.CelsiusToCelsius(input.Temperature));
+            return FloatRounder(FloatParser(CelsiusConverter.CelsiusToCelsius(input.Temperature)), fractionalCount);
         }
 
         /// <summary>
         /// Converts the FahrenheitConverter <paramref name="input"/> to Celsius
         /// </summary>
         /// <param name="input"> The value to be converted. </param>
+        /// <param name="fractionalCount"> The count of fractional after the decimal point. </param>
         /// <returns>
         /// The Celsius <see langword="float"/> result.
         /// </returns>
-        public static float ToCelsius(this FahrenheitFloat input)
+        public static float ToCelsius(this FahrenheitFloat input, int fractionalCount = -1)
         {
-            return FloatParser(FahrenheitConverter.FahrenheitToCelsius(input.Temperature));
+            return FloatRounder(FloatParser(FahrenheitConverter.FahrenheitToCelsius(input.Temperature)), fractionalCount);
         }
 
         /// <summary>
         /// Converts the GasConverter <paramref name="input"/> to Celsius
         /// </summary>
         /// <param name="input"> The value to be converted. </param>
+        /// <param name="fractionalCount"> The count of fractional after the decimal point. </param>
         /// <exception cref="T:System.ArgumentOutOfRangeException">Temp too low or too high for gas mark!</exception>
         /// <returns>
         /// The Celsius <see langword="float"/> result.
         /// </returns>
-        public static float ToCelsius(this GasFloat input)
-        {
-            return FloatParser(GasConverter.GasToCelsius(input.Temperature));
+        public static float ToCelsius(this GasFloat input, int fractionalCount = -1)
+{
+            return FloatRounder(FloatParser(GasConverter.GasToCelsius(input.Temperature)), fractionalCount);
         }
 
         /// <summary>
         /// Converts the KelvinConverter <paramref name="input"/> to Celsius
         /// </summary>
         /// <param name="input"> The value to be converted. </param>
+        /// <param name="fractionalCount"> The count of fractional after the decimal point. </param>
         /// <returns>
         /// The Celsius <see langword="float"/> result.
         /// </returns>
-        public static float ToCelsius(this KelvinFloat input)
+        public static float ToCelsius(this KelvinFloat input, int fractionalCount = -1)
         {
-            return (float)Math.Round(FloatParser(KelvinConverter.KelvinToCelsius(input.Temperature)), 2);
+            return FloatRounder(FloatParser(KelvinConverter.KelvinToCelsius(input.Temperature)), fractionalCount);
         }
 
         /// <summary>
         /// Converts the RankineConverter <paramref name="input"/> to Celsius
         /// </summary>
         /// <param name="input"> The value to be converted. </param>
+        /// <param name="fractionalCount"> The count of fractional after the decimal point. </param>
         /// <returns>
         /// The Celsius <see langword="float"/> result.
         /// </returns>
-        public static float ToCelsius(this RankineFloat input)
+        public static float ToCelsius(this RankineFloat input, int fractionalCount = -1)
         {
-            return (float)Math.Round(FloatParser(RankineConverter.RankineToCelsius(input.Temperature)), 2);
+            return FloatRounder(FloatParser(RankineConverter.RankineToCelsius(input.Temperature)), fractionalCount);
         }
 
         /// <summary>
         /// Converts the Celsius <paramref name="input"/> to FahrenheitConverter
         /// </summary>
         /// <param name="input"> The value to be converted. </param>
+        /// <param name="fractionalCount"> The count of fractional after the decimal point. </param>
         /// <exception cref="T:System.ArgumentOutOfRangeException">If calculated value is beyond the limits of the type.</exception>
         /// <returns>
         /// The FahrenheitConverter <see langword="float"/> result.
         /// </returns>
-        public static float ToFahrenheit(this CelsiusFloat input)
+        public static float ToFahrenheit(this CelsiusFloat input, int fractionalCount = -1)
         {
-            return FloatParser(CelsiusConverter.CelsiusToFahrenheit(input.Temperature));
+            return FloatRounder(FloatParser(CelsiusConverter.CelsiusToFahrenheit(input.Temperature)), fractionalCount);
         }
 
         /// <summary>
         /// Converts the FahrenheitConverter <paramref name="input"/> to FahrenheitConverter
         /// </summary>
         /// <param name="input"> The value to be converted. </param>
+        /// <param name="fractionalCount"> The count of fractional after the decimal point. </param>
         /// <returns>
         /// The FahrenheitConverter <see langword="float"/> result.
         /// </returns>
-        public static float ToFahrenheit(this FahrenheitFloat input)
+        public static float ToFahrenheit(this FahrenheitFloat input, int fractionalCount = -1)
         {
-            return FloatParser(FahrenheitConverter.FahrenheitToFahrenheit(input.Temperature));
+            return FloatRounder(FloatParser(FahrenheitConverter.FahrenheitToFahrenheit(input.Temperature)), fractionalCount);
         }
 
         /// <summary>
         /// Converts the GasConverter <paramref name="input"/> to FahrenheitConverter
         /// </summary>
         /// <param name="input"> The value to be converted. </param>
+        /// <param name="fractionalCount"> The count of fractional after the decimal point. </param>
         /// <exception cref="T:System.ArgumentOutOfRangeException">Temp too low or too high for gas mark!</exception>
         /// <returns>
         /// The FahrenheitConverter <see langword="float"/> result.
         /// </returns>
-        public static float ToFahrenheit(this GasFloat input)
+        public static float ToFahrenheit(this GasFloat input, int fractionalCount = -1)
         {
-            return FloatParser(GasConverter.GasToFahrenheit(input.Temperature));
+            return FloatRounder(FloatParser(GasConverter.GasToFahrenheit(input.Temperature)), fractionalCount);
         }
 
         /// <summary>
         /// Converts the KelvinConverter <paramref name="input"/> to FahrenheitConverter
         /// </summary>
         /// <param name="input"> The value to be converted. </param>
+        /// <param name="fractionalCount"> The count of fractional after the decimal point. </param>
         /// <exception cref="T:System.ArgumentOutOfRangeException">If calculated value is beyond the limits of the type.</exception>
         /// <returns>
         /// The FahrenheitConverter <see langword="float"/> result.
         /// </returns>
-        public static float ToFahrenheit(this KelvinFloat input)
+        public static float ToFahrenheit(this KelvinFloat input, int fractionalCount = -1)
         {
-            return (float)Math.Round(FloatParser(KelvinConverter.KelvinToFahrenheit(input.Temperature)), 2);
+            return FloatRounder(FloatParser(KelvinConverter.KelvinToFahrenheit(input.Temperature)), fractionalCount);
         }
 
         /// <summary>
         /// Converts the RankineConverter <paramref name="input"/> to FahrenheitConverter
         /// </summary>
         /// <param name="input"> The value to be converted. </param>
+        /// <param name="fractionalCount"> The count of fractional after the decimal point. </param>
         /// <returns>
         /// The FahrenheitConverter <see langword="float"/> result.
         /// </returns>
-        public static float ToFahrenheit(this RankineFloat input)
+        public static float ToFahrenheit(this RankineFloat input, int fractionalCount = -1)
         {
-            return FloatParser(RankineConverter.RankineToFahrenheit(input.Temperature));
+            return FloatRounder(FloatParser(RankineConverter.RankineToFahrenheit(input.Temperature)), fractionalCount);
         }
 
         /// <summary>
         /// Converts the Celsius <paramref name="input"/> to GasConverter
         /// </summary>
         /// <param name="input"> The value to be converted. </param>
+        /// <param name="fractionalCount"> The count of fractional after the decimal point. </param>
         /// <exception cref="T:System.ArgumentOutOfRangeException">Temp too low or too high for gas mark!</exception>
         /// <returns>
         /// The GasConverter <see langword="float"/> result.
         /// </returns>
-        public static float ToGas(this CelsiusFloat input)
+        public static float ToGas(this CelsiusFloat input, int fractionalCount = -1)
         {
-            return FloatParser(CelsiusConverter.CelsiusToGas(input.Temperature));
+            return FloatRounder(FloatParser(CelsiusConverter.CelsiusToGas(input.Temperature)), fractionalCount);
         }
 
         /// <summary>
         /// Converts the FahrenheitConverter <paramref name="input"/> to GasConverter
         /// </summary>
         /// <param name="input"> The value to be converted. </param>
+        /// <param name="fractionalCount"> The count of fractional after the decimal point. </param>
         /// <exception cref="T:System.ArgumentOutOfRangeException">Temp too low or too high for gas mark!</exception>
         /// <returns>
         /// The GasConverter <see langword="float"/> result.
         /// </returns>
-        public static float ToGas(this FahrenheitFloat input)
+        public static float ToGas(this FahrenheitFloat input, int fractionalCount = -1)
         {
-            return FloatParser(FahrenheitConverter.FahrenheitToGas(input.Temperature));
+            return FloatRounder(FloatParser(FahrenheitConverter.FahrenheitToGas(input.Temperature)), fractionalCount);
         }
 
         /// <summary>
         /// Converts the GasConverter <paramref name="input"/> to GasConverter
         /// </summary>
         /// <param name="input"> The value to be converted. </param>
+        /// <param name="fractionalCount"> The count of fractional after the decimal point. </param>
         /// <exception cref="T:System.ArgumentOutOfRangeException">Temp too low or too high for gas mark!</exception>
         /// <returns>
         /// The GasConverter <see langword="float"/> result.
         /// </returns>
-        public static float ToGas(this GasFloat input)
+        public static float ToGas(this GasFloat input, int fractionalCount = -1)
         {
-            return FloatParser(GasConverter.GasToGas(input.Temperature));
+            return FloatRounder(FloatParser(GasConverter.GasToGas(input.Temperature)), fractionalCount);
         }
 
         /// <summary>
         /// Converts the KelvinConverter <paramref name="input"/> to GasConverter
         /// </summary>
         /// <param name="input"> The value to be converted. </param>
+        /// <param name="fractionalCount"> The count of fractional after the decimal point. </param>
         /// <exception cref="T:System.ArgumentOutOfRangeException">Temp too low or too high for gas mark!</exception>
         /// <returns>
         /// The GasConverter <see langword="float"/> result.
         /// </returns>
-        public static float ToGas(this KelvinFloat input)
+        public static float ToGas(this KelvinFloat input, int fractionalCount = -1)
         {
-            return FloatParser(KelvinConverter.KelvinToGas(input.Temperature));
+            return FloatRounder(FloatParser(KelvinConverter.KelvinToGas(input.Temperature)), fractionalCount);
         }
 
         /// <summary>
         /// Converts the RankineConverter <paramref name="input"/> to GasConverter
         /// </summary>
         /// <param name="input"> The value to be converted. </param>
+        /// <param name="fractionalCount"> The count of fractional after the decimal point. </param>
         /// <exception cref="T:System.ArgumentOutOfRangeException">Temp too low or too high for gas mark!</exception>
         /// <returns>
         /// The GasConverter <see langword="float"/> result.
         /// </returns>
-        public static float ToGas(this RankineFloat input)
+        public static float ToGas(this RankineFloat input, int fractionalCount = -1)
         {
-            return FloatParser(RankineConverter.RankineToGas(input.Temperature));
+            return FloatRounder(FloatParser(RankineConverter.RankineToGas(input.Temperature)), fractionalCount);
         }
 
         /// <summary>
         /// Converts the Celsius <paramref name="input"/> to KelvinConverter
         /// </summary>
         /// <param name="input"> The value to be converted. </param>
+        /// <param name="fractionalCount"> The count of fractional after the decimal point. </param>
         /// <exception cref="T:System.ArgumentOutOfRangeException">If calculated value is beyond the limits of the type.</exception>
         /// <returns>
         /// The KelvinConverter <see langword="float"/> result.
         /// </returns>
-        public static float ToKelvin(this CelsiusFloat input)
+        public static float ToKelvin(this CelsiusFloat input, int fractionalCount = -1)
         {
-            return FloatParser(CelsiusConverter.CelsiusToKelvin(input.Temperature));
+            return FloatRounder(FloatParser(CelsiusConverter.CelsiusToKelvin(input.Temperature)), fractionalCount);
         }
 
         /// <summary>
         /// Converts the FahrenheitConverter <paramref name="input"/> to KelvinConverter
         /// </summary>
         /// <param name="input"> The value to be converted. </param>
+        /// <param name="fractionalCount"> The count of fractional after the decimal point. </param>
         /// <exception cref="T:System.ArgumentOutOfRangeException">If calculated value is beyond the limits of the type.</exception>
         /// <returns>
         /// The KelvinConverter <see langword="float"/> result.
         /// </returns>
-        public static float ToKelvin(this FahrenheitFloat input)
+        public static float ToKelvin(this FahrenheitFloat input, int fractionalCount = -1)
         {
-            return FloatParser(FahrenheitConverter.FahrenheitToKelvin(input.Temperature));
+            return FloatRounder(FloatParser(FahrenheitConverter.FahrenheitToKelvin(input.Temperature)), fractionalCount);
         }
 
         /// <summary>
         /// Converts the GasConverter <paramref name="input"/> to KelvinConverter
         /// </summary>
         /// <param name="input"> The value to be converted. </param>
+        /// <param name="fractionalCount"> The count of fractional after the decimal point. </param>
         /// <exception cref="T:System.ArgumentOutOfRangeException">Temp too low or too high for gas mark!</exception>
         /// <returns>
         /// The KelvinConverter <see langword="float"/> result.
         /// </returns>
-        public static float ToKelvin(this GasFloat input)
+        public static float ToKelvin(this GasFloat input, int fractionalCount = -1)
         {
-            return FloatParser(GasConverter.GasToKelvin(input.Temperature));
+            return FloatRounder(FloatParser(GasConverter.GasToKelvin(input.Temperature)), fractionalCount);
         }
 
         /// <summary>
         /// Converts the KelvinConverter <paramref name="input"/> to KelvinConverter
         /// </summary>
         /// <param name="input"> The value to be converted. </param>
+        /// <param name="fractionalCount"> The count of fractional after the decimal point. </param>
         /// <returns>
         /// The KelvinConverter <see langword="float"/> result.
         /// </returns>
-        public static float ToKelvin(this KelvinFloat input)
+        public static float ToKelvin(this KelvinFloat input, int fractionalCount = -1)
         {
-            return FloatParser(KelvinConverter.KelvinToKelvin(input.Temperature));
+            return FloatRounder(FloatParser(KelvinConverter.KelvinToKelvin(input.Temperature)), fractionalCount);
         }
 
         /// <summary>
         /// Converts the RankineConverter <paramref name="input" /> to KelvinConverter
         /// </summary>
         /// <param name="input"> The value to be converted. </param>
+        /// <param name="fractionalCount"> The count of fractional after the decimal point. </param>
         /// <exception cref="ArgumentOutOfRangeException">
         /// If calculated value is beyond the limits of the type.
         /// </exception>
         /// <returns>
         /// The KelvinConverter <see langword="float"/> result.
         /// </returns>
-        public static float ToKelvin(this RankineFloat input)
+        public static float ToKelvin(this RankineFloat input, int fractionalCount = -1)
         {
-            return FloatParser(RankineConverter.RankineToKelvin(input.Temperature));
+            return FloatRounder(FloatParser(RankineConverter.RankineToKelvin(input.Temperature)), fractionalCount);
         }
 
         /// <summary>
         /// Converts the Celsius <paramref name="input"/> to RankineConverter
         /// </summary>
         /// <param name="input"> The value to be converted. </param>
+        /// <param name="fractionalCount"> The count of fractional after the decimal point. </param>
         /// <exception cref="T:System.ArgumentOutOfRangeException">If calculated value is beyond the limits of the type.</exception>
         /// <returns>
         /// The RankineConverter <see langword="float"/> result.
         /// </returns>
-        public static float ToRankine(this CelsiusFloat input)
+        public static float ToRankine(this CelsiusFloat input, int fractionalCount = -1)
         {
-            return FloatParser(CelsiusConverter.CelsiusToRankine(input.Temperature));
+            return FloatRounder(FloatParser(CelsiusConverter.CelsiusToRankine(input.Temperature)), fractionalCount);
         }
 
         /// <summary>
         /// Converts the FahrenheitConverter <paramref name="input"/> to RankineConverter
         /// </summary>
         /// <param name="input"> The value to be converted. </param>
+        /// <param name="fractionalCount"> The count of fractional after the decimal point. </param>
         /// <exception cref="T:System.ArgumentOutOfRangeException">If calculated value is beyond the limits of the type.</exception>
         /// <returns>
         /// The RankineConverter <see langword="float"/> result.
         /// </returns>
-        public static float ToRankine(this FahrenheitFloat input)
+        public static float ToRankine(this FahrenheitFloat input, int fractionalCount = -1)
         {
-            return FloatParser(FahrenheitConverter.FahrenheitToRankine(input.Temperature));
+            return FloatRounder(FloatParser(FahrenheitConverter.FahrenheitToRankine(input.Temperature)), fractionalCount);
         }
 
         /// <summary>
         /// Converts the GasConverter <paramref name="input"/> to RankineConverter
         /// </summary>
         /// <param name="input"> The value to be converted. </param>
+        /// <param name="fractionalCount"> The count of fractional after the decimal point. </param>
         /// <exception cref="T:System.ArgumentOutOfRangeException">Temp too low or too high for gas mark!</exception>
         /// <returns>
         /// The RankineConverter <see langword="float"/> result.
         /// </returns>
-        public static float ToRankine(this GasFloat input)
+        public static float ToRankine(this GasFloat input, int fractionalCount = -1)
         {
-            return FloatParser(GasConverter.GasToRankine(input.Temperature));
+            return FloatRounder(FloatParser(GasConverter.GasToRankine(input.Temperature)), fractionalCount);
         }
 
         /// <summary>
         /// Converts the KelvinConverter <paramref name="input"/> to RankineConverter
         /// </summary>
         /// <param name="input"> The value to be converted. </param>
+        /// <param name="fractionalCount"> The count of fractional after the decimal point. </param>
         /// <exception cref="T:System.ArgumentOutOfRangeException">If calculated value is beyond the limits of the type.</exception>
         /// <returns>
         /// The RankineConverter <see langword="float"/> result.
         /// </returns>
-        public static float ToRankine(this KelvinFloat input)
+        public static float ToRankine(this KelvinFloat input, int fractionalCount = -1)
         {
-            return FloatParser(KelvinConverter.KelvinToRankine(input.Temperature));
+            return FloatRounder(FloatParser(KelvinConverter.KelvinToRankine(input.Temperature)), fractionalCount);
         }
 
         /// <summary>
         /// Converts the RankineConverter <paramref name="input"/> to RankineConverter
         /// </summary>
         /// <param name="input"> The value to be converted. </param>
+        /// <param name="fractionalCount"> The count of fractional after the decimal point. </param>
         /// <returns>
         /// The RankineConverter <see langword="float"/> result.
         /// </returns>
-        public static float ToRankine(this RankineFloat input)
+        public static float ToRankine(this RankineFloat input, int fractionalCount = -1)
         {
-            return FloatParser(RankineConverter.RankineToRankine(input.Temperature));
+            return FloatRounder(FloatParser(RankineConverter.RankineToRankine(input.Temperature)), fractionalCount);
         }
 
         /// <summary>
@@ -339,40 +364,41 @@
         /// </summary>
         /// <typeparam name="TInput"> The temperature type to be converted to. </typeparam>
         /// <param name="input"> The value to be converted. </param>
+        /// <param name="fractionalCount"> The count of fractional after the decimal point. </param>
         /// <exception cref="ArgumentException"> The TInput type is not a valid type for this method. </exception>
         /// <returns>
         /// The result of the conversion.
         /// </returns>
-        public static float To<TInput>(this FloatBase input)
+        public static float To<TInput>(this FloatBase input, int fractionalCount = -1)
             where TInput : TemperatureBase
         {
             return typeof(TInput).Name switch
             {
-                nameof(Celsius) when input is CelsiusFloat castInput => FloatParser(CelsiusConverter.CelsiusToCelsius(castInput.Temperature)),
-                nameof(Celsius) when input is FahrenheitFloat castInput => FloatParser(FahrenheitConverter.FahrenheitToCelsius(castInput.Temperature)),
-                nameof(Celsius) when input is KelvinFloat castInput => (float)Math.Round(FloatParser(KelvinConverter.KelvinToCelsius(castInput.Temperature)), 2),
-                nameof(Celsius) when input is GasFloat castInput => FloatParser(GasConverter.GasToCelsius(castInput.Temperature)),
-                nameof(Celsius) when input is RankineFloat castInput => (float)Math.Round(FloatParser(RankineConverter.RankineToCelsius(castInput.Temperature)), 2),
-                nameof(Fahrenheit) when input is CelsiusFloat castInput => FloatParser(CelsiusConverter.CelsiusToFahrenheit(castInput.Temperature)),
-                nameof(Fahrenheit) when input is FahrenheitFloat castInput => FloatParser(FahrenheitConverter.FahrenheitToFahrenheit(castInput.Temperature)),
-                nameof(Fahrenheit) when input is KelvinFloat castInput => (float)Math.Round(FloatParser(KelvinConverter.KelvinToFahrenheit(castInput.Temperature)), 2),
-                nameof(Fahrenheit) when input is GasFloat castInput => FloatParser(GasConverter.GasToFahrenheit(castInput.Temperature)),
-                nameof(Fahrenheit) when input is RankineFloat castInput => FloatParser(RankineConverter.RankineToFahrenheit(castInput.Temperature)),
-                nameof(Kelvin) when input is CelsiusFloat castInput => FloatParser(CelsiusConverter.CelsiusToKelvin(castInput.Temperature)),
-                nameof(Kelvin) when input is FahrenheitFloat castInput => FloatParser(FahrenheitConverter.FahrenheitToKelvin(castInput.Temperature)),
-                nameof(Kelvin) when input is KelvinFloat castInput => FloatParser(KelvinConverter.KelvinToKelvin(castInput.Temperature)),
-                nameof(Kelvin) when input is GasFloat castInput => FloatParser(GasConverter.GasToKelvin(castInput.Temperature)),
-                nameof(Kelvin) when input is RankineFloat castInput => FloatParser(RankineConverter.RankineToKelvin(castInput.Temperature)),
-                nameof(Gas) when input is CelsiusFloat castInput => FloatParser(CelsiusConverter.CelsiusToGas(castInput.Temperature)),
-                nameof(Gas) when input is FahrenheitFloat castInput => FloatParser(FahrenheitConverter.FahrenheitToGas(castInput.Temperature)),
-                nameof(Gas) when input is KelvinFloat castInput => FloatParser(KelvinConverter.KelvinToGas(castInput.Temperature)),
-                nameof(Gas) when input is GasFloat castInput => FloatParser(GasConverter.GasToGas(castInput.Temperature)),
-                nameof(Gas) when input is RankineFloat castInput => FloatParser(RankineConverter.RankineToGas(castInput.Temperature)),
-                nameof(Rankine) when input is CelsiusFloat castInput => FloatParser(CelsiusConverter.CelsiusToRankine(castInput.Temperature)),
-                nameof(Rankine) when input is FahrenheitFloat castInput => FloatParser(FahrenheitConverter.FahrenheitToRankine(castInput.Temperature)),
-                nameof(Rankine) when input is KelvinFloat castInput => FloatParser(KelvinConverter.KelvinToRankine(castInput.Temperature)),
-                nameof(Rankine) when input is GasFloat castInput => FloatParser(GasConverter.GasToRankine(castInput.Temperature)),
-                nameof(Rankine) when input is RankineFloat castInput => FloatParser(RankineConverter.RankineToRankine(castInput.Temperature)),
+                nameof(Celsius) when input is CelsiusFloat castInput => FloatRounder(FloatParser(CelsiusConverter.CelsiusToCelsius(castInput.Temperature)), fractionalCount),
+                nameof(Celsius) when input is FahrenheitFloat castInput => FloatRounder(FloatParser(FahrenheitConverter.FahrenheitToCelsius(castInput.Temperature)), fractionalCount),
+                nameof(Celsius) when input is KelvinFloat castInput => FloatRounder(FloatParser(KelvinConverter.KelvinToCelsius(castInput.Temperature)), fractionalCount),
+                nameof(Celsius) when input is GasFloat castInput => FloatRounder(FloatParser(GasConverter.GasToCelsius(castInput.Temperature)), fractionalCount),
+                nameof(Celsius) when input is RankineFloat castInput => FloatRounder(FloatParser(RankineConverter.RankineToCelsius(castInput.Temperature)), fractionalCount),
+                nameof(Fahrenheit) when input is CelsiusFloat castInput => FloatRounder(FloatParser(CelsiusConverter.CelsiusToFahrenheit(castInput.Temperature)), fractionalCount),
+                nameof(Fahrenheit) when input is FahrenheitFloat castInput => FloatRounder(FloatParser(FahrenheitConverter.FahrenheitToFahrenheit(castInput.Temperature)), fractionalCount),
+                nameof(Fahrenheit) when input is KelvinFloat castInput => FloatRounder(FloatParser(KelvinConverter.KelvinToFahrenheit(castInput.Temperature)), fractionalCount),
+                nameof(Fahrenheit) when input is GasFloat castInput => FloatRounder(FloatParser(GasConverter.GasToFahrenheit(castInput.Temperature)), fractionalCount),
+                nameof(Fahrenheit) when input is RankineFloat castInput => FloatRounder(FloatParser(RankineConverter.RankineToFahrenheit(castInput.Temperature)), fractionalCount),
+                nameof(Kelvin) when input is CelsiusFloat castInput => FloatRounder(FloatParser(CelsiusConverter.CelsiusToKelvin(castInput.Temperature)), fractionalCount),
+                nameof(Kelvin) when input is FahrenheitFloat castInput => FloatRounder(FloatParser(FahrenheitConverter.FahrenheitToKelvin(castInput.Temperature)), fractionalCount),
+                nameof(Kelvin) when input is KelvinFloat castInput => FloatRounder(FloatParser(KelvinConverter.KelvinToKelvin(castInput.Temperature)), fractionalCount),
+                nameof(Kelvin) when input is GasFloat castInput => FloatRounder(FloatParser(GasConverter.GasToKelvin(castInput.Temperature)), fractionalCount),
+                nameof(Kelvin) when input is RankineFloat castInput => FloatRounder(FloatParser(RankineConverter.RankineToKelvin(castInput.Temperature)), fractionalCount),
+                nameof(Gas) when input is CelsiusFloat castInput => FloatRounder(FloatParser(CelsiusConverter.CelsiusToGas(castInput.Temperature)), fractionalCount),
+                nameof(Gas) when input is FahrenheitFloat castInput => FloatRounder(FloatParser(FahrenheitConverter.FahrenheitToGas(castInput.Temperature)), fractionalCount),
+                nameof(Gas) when input is KelvinFloat castInput => FloatRounder(FloatParser(KelvinConverter.KelvinToGas(castInput.Temperature)), fractionalCount),
+                nameof(Gas) when input is GasFloat castInput => FloatRounder(FloatParser(GasConverter.GasToGas(castInput.Temperature)), fractionalCount),
+                nameof(Gas) when input is RankineFloat castInput => FloatRounder(FloatParser(RankineConverter.RankineToGas(castInput.Temperature)), fractionalCount),
+                nameof(Rankine) when input is CelsiusFloat castInput => FloatRounder(FloatParser(CelsiusConverter.CelsiusToRankine(castInput.Temperature)), fractionalCount),
+                nameof(Rankine) when input is FahrenheitFloat castInput => FloatRounder(FloatParser(FahrenheitConverter.FahrenheitToRankine(castInput.Temperature)), fractionalCount),
+                nameof(Rankine) when input is KelvinFloat castInput => FloatRounder(FloatParser(KelvinConverter.KelvinToRankine(castInput.Temperature)), fractionalCount),
+                nameof(Rankine) when input is GasFloat castInput => FloatRounder(FloatParser(GasConverter.GasToRankine(castInput.Temperature)), fractionalCount),
+                nameof(Rankine) when input is RankineFloat castInput => FloatRounder(FloatParser(RankineConverter.RankineToRankine(castInput.Temperature)), fractionalCount),
                 _ => throw new ArgumentException($"Invalid type: {typeof(TInput).Name}")
             };
         }
@@ -384,6 +410,14 @@
             if (float.IsInfinity(convertedTemp)) throw new ArgumentOutOfRangeException(Constants.ValueOutOfRangeForType);
 
             return convertedTemp;
+        }
+
+        private static float FloatRounder(float input, int fractionalCount = -1)
+        {
+            if (fractionalCount < 0)
+                return input;
+
+            return (float)Math.Round(input, fractionalCount);
         }
     }
 }

--- a/src/Converter.Temperature/Extensions/To/ToFloatExtensions.cs
+++ b/src/Converter.Temperature/Extensions/To/ToFloatExtensions.cs
@@ -25,7 +25,7 @@
         /// </returns>
         public static float ToCelsius(this CelsiusFloat input, int fractionalCount = -1)
         {
-            return FloatRounder(FloatParser(CelsiusConverter.CelsiusToCelsius(input.Temperature)), fractionalCount);
+            return Rounder(Parser(CelsiusConverter.CelsiusToCelsius(input.Temperature)), fractionalCount);
         }
 
         /// <summary>
@@ -38,7 +38,7 @@
         /// </returns>
         public static float ToCelsius(this FahrenheitFloat input, int fractionalCount = -1)
         {
-            return FloatRounder(FloatParser(FahrenheitConverter.FahrenheitToCelsius(input.Temperature)), fractionalCount);
+            return Rounder(Parser(FahrenheitConverter.FahrenheitToCelsius(input.Temperature)), fractionalCount);
         }
 
         /// <summary>
@@ -52,7 +52,7 @@
         /// </returns>
         public static float ToCelsius(this GasFloat input, int fractionalCount = -1)
 {
-            return FloatRounder(FloatParser(GasConverter.GasToCelsius(input.Temperature)), fractionalCount);
+            return Rounder(Parser(GasConverter.GasToCelsius(input.Temperature)), fractionalCount);
         }
 
         /// <summary>
@@ -65,7 +65,7 @@
         /// </returns>
         public static float ToCelsius(this KelvinFloat input, int fractionalCount = -1)
         {
-            return FloatRounder(FloatParser(KelvinConverter.KelvinToCelsius(input.Temperature)), fractionalCount);
+            return Rounder(Parser(KelvinConverter.KelvinToCelsius(input.Temperature)), fractionalCount);
         }
 
         /// <summary>
@@ -78,7 +78,7 @@
         /// </returns>
         public static float ToCelsius(this RankineFloat input, int fractionalCount = -1)
         {
-            return FloatRounder(FloatParser(RankineConverter.RankineToCelsius(input.Temperature)), fractionalCount);
+            return Rounder(Parser(RankineConverter.RankineToCelsius(input.Temperature)), fractionalCount);
         }
 
         /// <summary>
@@ -92,7 +92,7 @@
         /// </returns>
         public static float ToFahrenheit(this CelsiusFloat input, int fractionalCount = -1)
         {
-            return FloatRounder(FloatParser(CelsiusConverter.CelsiusToFahrenheit(input.Temperature)), fractionalCount);
+            return Rounder(Parser(CelsiusConverter.CelsiusToFahrenheit(input.Temperature)), fractionalCount);
         }
 
         /// <summary>
@@ -105,7 +105,7 @@
         /// </returns>
         public static float ToFahrenheit(this FahrenheitFloat input, int fractionalCount = -1)
         {
-            return FloatRounder(FloatParser(FahrenheitConverter.FahrenheitToFahrenheit(input.Temperature)), fractionalCount);
+            return Rounder(Parser(FahrenheitConverter.FahrenheitToFahrenheit(input.Temperature)), fractionalCount);
         }
 
         /// <summary>
@@ -119,7 +119,7 @@
         /// </returns>
         public static float ToFahrenheit(this GasFloat input, int fractionalCount = -1)
         {
-            return FloatRounder(FloatParser(GasConverter.GasToFahrenheit(input.Temperature)), fractionalCount);
+            return Rounder(Parser(GasConverter.GasToFahrenheit(input.Temperature)), fractionalCount);
         }
 
         /// <summary>
@@ -133,7 +133,7 @@
         /// </returns>
         public static float ToFahrenheit(this KelvinFloat input, int fractionalCount = -1)
         {
-            return FloatRounder(FloatParser(KelvinConverter.KelvinToFahrenheit(input.Temperature)), fractionalCount);
+            return Rounder(Parser(KelvinConverter.KelvinToFahrenheit(input.Temperature)), fractionalCount);
         }
 
         /// <summary>
@@ -146,7 +146,7 @@
         /// </returns>
         public static float ToFahrenheit(this RankineFloat input, int fractionalCount = -1)
         {
-            return FloatRounder(FloatParser(RankineConverter.RankineToFahrenheit(input.Temperature)), fractionalCount);
+            return Rounder(Parser(RankineConverter.RankineToFahrenheit(input.Temperature)), fractionalCount);
         }
 
         /// <summary>
@@ -160,7 +160,7 @@
         /// </returns>
         public static float ToGas(this CelsiusFloat input, int fractionalCount = -1)
         {
-            return FloatRounder(FloatParser(CelsiusConverter.CelsiusToGas(input.Temperature)), fractionalCount);
+            return Rounder(Parser(CelsiusConverter.CelsiusToGas(input.Temperature)), fractionalCount);
         }
 
         /// <summary>
@@ -174,7 +174,7 @@
         /// </returns>
         public static float ToGas(this FahrenheitFloat input, int fractionalCount = -1)
         {
-            return FloatRounder(FloatParser(FahrenheitConverter.FahrenheitToGas(input.Temperature)), fractionalCount);
+            return Rounder(Parser(FahrenheitConverter.FahrenheitToGas(input.Temperature)), fractionalCount);
         }
 
         /// <summary>
@@ -188,7 +188,7 @@
         /// </returns>
         public static float ToGas(this GasFloat input, int fractionalCount = -1)
         {
-            return FloatRounder(FloatParser(GasConverter.GasToGas(input.Temperature)), fractionalCount);
+            return Rounder(Parser(GasConverter.GasToGas(input.Temperature)), fractionalCount);
         }
 
         /// <summary>
@@ -202,7 +202,7 @@
         /// </returns>
         public static float ToGas(this KelvinFloat input, int fractionalCount = -1)
         {
-            return FloatRounder(FloatParser(KelvinConverter.KelvinToGas(input.Temperature)), fractionalCount);
+            return Rounder(Parser(KelvinConverter.KelvinToGas(input.Temperature)), fractionalCount);
         }
 
         /// <summary>
@@ -216,7 +216,7 @@
         /// </returns>
         public static float ToGas(this RankineFloat input, int fractionalCount = -1)
         {
-            return FloatRounder(FloatParser(RankineConverter.RankineToGas(input.Temperature)), fractionalCount);
+            return Rounder(Parser(RankineConverter.RankineToGas(input.Temperature)), fractionalCount);
         }
 
         /// <summary>
@@ -230,7 +230,7 @@
         /// </returns>
         public static float ToKelvin(this CelsiusFloat input, int fractionalCount = -1)
         {
-            return FloatRounder(FloatParser(CelsiusConverter.CelsiusToKelvin(input.Temperature)), fractionalCount);
+            return Rounder(Parser(CelsiusConverter.CelsiusToKelvin(input.Temperature)), fractionalCount);
         }
 
         /// <summary>
@@ -244,7 +244,7 @@
         /// </returns>
         public static float ToKelvin(this FahrenheitFloat input, int fractionalCount = -1)
         {
-            return FloatRounder(FloatParser(FahrenheitConverter.FahrenheitToKelvin(input.Temperature)), fractionalCount);
+            return Rounder(Parser(FahrenheitConverter.FahrenheitToKelvin(input.Temperature)), fractionalCount);
         }
 
         /// <summary>
@@ -258,7 +258,7 @@
         /// </returns>
         public static float ToKelvin(this GasFloat input, int fractionalCount = -1)
         {
-            return FloatRounder(FloatParser(GasConverter.GasToKelvin(input.Temperature)), fractionalCount);
+            return Rounder(Parser(GasConverter.GasToKelvin(input.Temperature)), fractionalCount);
         }
 
         /// <summary>
@@ -271,7 +271,7 @@
         /// </returns>
         public static float ToKelvin(this KelvinFloat input, int fractionalCount = -1)
         {
-            return FloatRounder(FloatParser(KelvinConverter.KelvinToKelvin(input.Temperature)), fractionalCount);
+            return Rounder(Parser(KelvinConverter.KelvinToKelvin(input.Temperature)), fractionalCount);
         }
 
         /// <summary>
@@ -287,7 +287,7 @@
         /// </returns>
         public static float ToKelvin(this RankineFloat input, int fractionalCount = -1)
         {
-            return FloatRounder(FloatParser(RankineConverter.RankineToKelvin(input.Temperature)), fractionalCount);
+            return Rounder(Parser(RankineConverter.RankineToKelvin(input.Temperature)), fractionalCount);
         }
 
         /// <summary>
@@ -301,7 +301,7 @@
         /// </returns>
         public static float ToRankine(this CelsiusFloat input, int fractionalCount = -1)
         {
-            return FloatRounder(FloatParser(CelsiusConverter.CelsiusToRankine(input.Temperature)), fractionalCount);
+            return Rounder(Parser(CelsiusConverter.CelsiusToRankine(input.Temperature)), fractionalCount);
         }
 
         /// <summary>
@@ -315,7 +315,7 @@
         /// </returns>
         public static float ToRankine(this FahrenheitFloat input, int fractionalCount = -1)
         {
-            return FloatRounder(FloatParser(FahrenheitConverter.FahrenheitToRankine(input.Temperature)), fractionalCount);
+            return Rounder(Parser(FahrenheitConverter.FahrenheitToRankine(input.Temperature)), fractionalCount);
         }
 
         /// <summary>
@@ -329,7 +329,7 @@
         /// </returns>
         public static float ToRankine(this GasFloat input, int fractionalCount = -1)
         {
-            return FloatRounder(FloatParser(GasConverter.GasToRankine(input.Temperature)), fractionalCount);
+            return Rounder(Parser(GasConverter.GasToRankine(input.Temperature)), fractionalCount);
         }
 
         /// <summary>
@@ -343,7 +343,7 @@
         /// </returns>
         public static float ToRankine(this KelvinFloat input, int fractionalCount = -1)
         {
-            return FloatRounder(FloatParser(KelvinConverter.KelvinToRankine(input.Temperature)), fractionalCount);
+            return Rounder(Parser(KelvinConverter.KelvinToRankine(input.Temperature)), fractionalCount);
         }
 
         /// <summary>
@@ -356,7 +356,7 @@
         /// </returns>
         public static float ToRankine(this RankineFloat input, int fractionalCount = -1)
         {
-            return FloatRounder(FloatParser(RankineConverter.RankineToRankine(input.Temperature)), fractionalCount);
+            return Rounder(Parser(RankineConverter.RankineToRankine(input.Temperature)), fractionalCount);
         }
 
         /// <summary>
@@ -374,36 +374,36 @@
         {
             return typeof(TInput).Name switch
             {
-                nameof(Celsius) when input is CelsiusFloat castInput => FloatRounder(FloatParser(CelsiusConverter.CelsiusToCelsius(castInput.Temperature)), fractionalCount),
-                nameof(Celsius) when input is FahrenheitFloat castInput => FloatRounder(FloatParser(FahrenheitConverter.FahrenheitToCelsius(castInput.Temperature)), fractionalCount),
-                nameof(Celsius) when input is KelvinFloat castInput => FloatRounder(FloatParser(KelvinConverter.KelvinToCelsius(castInput.Temperature)), fractionalCount),
-                nameof(Celsius) when input is GasFloat castInput => FloatRounder(FloatParser(GasConverter.GasToCelsius(castInput.Temperature)), fractionalCount),
-                nameof(Celsius) when input is RankineFloat castInput => FloatRounder(FloatParser(RankineConverter.RankineToCelsius(castInput.Temperature)), fractionalCount),
-                nameof(Fahrenheit) when input is CelsiusFloat castInput => FloatRounder(FloatParser(CelsiusConverter.CelsiusToFahrenheit(castInput.Temperature)), fractionalCount),
-                nameof(Fahrenheit) when input is FahrenheitFloat castInput => FloatRounder(FloatParser(FahrenheitConverter.FahrenheitToFahrenheit(castInput.Temperature)), fractionalCount),
-                nameof(Fahrenheit) when input is KelvinFloat castInput => FloatRounder(FloatParser(KelvinConverter.KelvinToFahrenheit(castInput.Temperature)), fractionalCount),
-                nameof(Fahrenheit) when input is GasFloat castInput => FloatRounder(FloatParser(GasConverter.GasToFahrenheit(castInput.Temperature)), fractionalCount),
-                nameof(Fahrenheit) when input is RankineFloat castInput => FloatRounder(FloatParser(RankineConverter.RankineToFahrenheit(castInput.Temperature)), fractionalCount),
-                nameof(Kelvin) when input is CelsiusFloat castInput => FloatRounder(FloatParser(CelsiusConverter.CelsiusToKelvin(castInput.Temperature)), fractionalCount),
-                nameof(Kelvin) when input is FahrenheitFloat castInput => FloatRounder(FloatParser(FahrenheitConverter.FahrenheitToKelvin(castInput.Temperature)), fractionalCount),
-                nameof(Kelvin) when input is KelvinFloat castInput => FloatRounder(FloatParser(KelvinConverter.KelvinToKelvin(castInput.Temperature)), fractionalCount),
-                nameof(Kelvin) when input is GasFloat castInput => FloatRounder(FloatParser(GasConverter.GasToKelvin(castInput.Temperature)), fractionalCount),
-                nameof(Kelvin) when input is RankineFloat castInput => FloatRounder(FloatParser(RankineConverter.RankineToKelvin(castInput.Temperature)), fractionalCount),
-                nameof(Gas) when input is CelsiusFloat castInput => FloatRounder(FloatParser(CelsiusConverter.CelsiusToGas(castInput.Temperature)), fractionalCount),
-                nameof(Gas) when input is FahrenheitFloat castInput => FloatRounder(FloatParser(FahrenheitConverter.FahrenheitToGas(castInput.Temperature)), fractionalCount),
-                nameof(Gas) when input is KelvinFloat castInput => FloatRounder(FloatParser(KelvinConverter.KelvinToGas(castInput.Temperature)), fractionalCount),
-                nameof(Gas) when input is GasFloat castInput => FloatRounder(FloatParser(GasConverter.GasToGas(castInput.Temperature)), fractionalCount),
-                nameof(Gas) when input is RankineFloat castInput => FloatRounder(FloatParser(RankineConverter.RankineToGas(castInput.Temperature)), fractionalCount),
-                nameof(Rankine) when input is CelsiusFloat castInput => FloatRounder(FloatParser(CelsiusConverter.CelsiusToRankine(castInput.Temperature)), fractionalCount),
-                nameof(Rankine) when input is FahrenheitFloat castInput => FloatRounder(FloatParser(FahrenheitConverter.FahrenheitToRankine(castInput.Temperature)), fractionalCount),
-                nameof(Rankine) when input is KelvinFloat castInput => FloatRounder(FloatParser(KelvinConverter.KelvinToRankine(castInput.Temperature)), fractionalCount),
-                nameof(Rankine) when input is GasFloat castInput => FloatRounder(FloatParser(GasConverter.GasToRankine(castInput.Temperature)), fractionalCount),
-                nameof(Rankine) when input is RankineFloat castInput => FloatRounder(FloatParser(RankineConverter.RankineToRankine(castInput.Temperature)), fractionalCount),
+                nameof(Celsius) when input is CelsiusFloat castInput => Rounder(Parser(CelsiusConverter.CelsiusToCelsius(castInput.Temperature)), fractionalCount),
+                nameof(Celsius) when input is FahrenheitFloat castInput => Rounder(Parser(FahrenheitConverter.FahrenheitToCelsius(castInput.Temperature)), fractionalCount),
+                nameof(Celsius) when input is KelvinFloat castInput => Rounder(Parser(KelvinConverter.KelvinToCelsius(castInput.Temperature)), fractionalCount),
+                nameof(Celsius) when input is GasFloat castInput => Rounder(Parser(GasConverter.GasToCelsius(castInput.Temperature)), fractionalCount),
+                nameof(Celsius) when input is RankineFloat castInput => Rounder(Parser(RankineConverter.RankineToCelsius(castInput.Temperature)), fractionalCount),
+                nameof(Fahrenheit) when input is CelsiusFloat castInput => Rounder(Parser(CelsiusConverter.CelsiusToFahrenheit(castInput.Temperature)), fractionalCount),
+                nameof(Fahrenheit) when input is FahrenheitFloat castInput => Rounder(Parser(FahrenheitConverter.FahrenheitToFahrenheit(castInput.Temperature)), fractionalCount),
+                nameof(Fahrenheit) when input is KelvinFloat castInput => Rounder(Parser(KelvinConverter.KelvinToFahrenheit(castInput.Temperature)), fractionalCount),
+                nameof(Fahrenheit) when input is GasFloat castInput => Rounder(Parser(GasConverter.GasToFahrenheit(castInput.Temperature)), fractionalCount),
+                nameof(Fahrenheit) when input is RankineFloat castInput => Rounder(Parser(RankineConverter.RankineToFahrenheit(castInput.Temperature)), fractionalCount),
+                nameof(Kelvin) when input is CelsiusFloat castInput => Rounder(Parser(CelsiusConverter.CelsiusToKelvin(castInput.Temperature)), fractionalCount),
+                nameof(Kelvin) when input is FahrenheitFloat castInput => Rounder(Parser(FahrenheitConverter.FahrenheitToKelvin(castInput.Temperature)), fractionalCount),
+                nameof(Kelvin) when input is KelvinFloat castInput => Rounder(Parser(KelvinConverter.KelvinToKelvin(castInput.Temperature)), fractionalCount),
+                nameof(Kelvin) when input is GasFloat castInput => Rounder(Parser(GasConverter.GasToKelvin(castInput.Temperature)), fractionalCount),
+                nameof(Kelvin) when input is RankineFloat castInput => Rounder(Parser(RankineConverter.RankineToKelvin(castInput.Temperature)), fractionalCount),
+                nameof(Gas) when input is CelsiusFloat castInput => Rounder(Parser(CelsiusConverter.CelsiusToGas(castInput.Temperature)), fractionalCount),
+                nameof(Gas) when input is FahrenheitFloat castInput => Rounder(Parser(FahrenheitConverter.FahrenheitToGas(castInput.Temperature)), fractionalCount),
+                nameof(Gas) when input is KelvinFloat castInput => Rounder(Parser(KelvinConverter.KelvinToGas(castInput.Temperature)), fractionalCount),
+                nameof(Gas) when input is GasFloat castInput => Rounder(Parser(GasConverter.GasToGas(castInput.Temperature)), fractionalCount),
+                nameof(Gas) when input is RankineFloat castInput => Rounder(Parser(RankineConverter.RankineToGas(castInput.Temperature)), fractionalCount),
+                nameof(Rankine) when input is CelsiusFloat castInput => Rounder(Parser(CelsiusConverter.CelsiusToRankine(castInput.Temperature)), fractionalCount),
+                nameof(Rankine) when input is FahrenheitFloat castInput => Rounder(Parser(FahrenheitConverter.FahrenheitToRankine(castInput.Temperature)), fractionalCount),
+                nameof(Rankine) when input is KelvinFloat castInput => Rounder(Parser(KelvinConverter.KelvinToRankine(castInput.Temperature)), fractionalCount),
+                nameof(Rankine) when input is GasFloat castInput => Rounder(Parser(GasConverter.GasToRankine(castInput.Temperature)), fractionalCount),
+                nameof(Rankine) when input is RankineFloat castInput => Rounder(Parser(RankineConverter.RankineToRankine(castInput.Temperature)), fractionalCount),
                 _ => throw new ArgumentException($"Invalid type: {typeof(TInput).Name}")
             };
         }
 
-        private static float FloatParser(double temp)
+        private static float Parser(double temp)
         {
             float.TryParse(temp.ToString(CultureInfo.InvariantCulture), out var convertedTemp);
 
@@ -412,7 +412,7 @@
             return convertedTemp;
         }
 
-        private static float FloatRounder(float input, int fractionalCount = -1)
+        private static float Rounder(float input, int fractionalCount = -1)
         {
             if (fractionalCount < 0)
                 return input;

--- a/src/Converter.Temperature/Extensions/To/ToFloatExtensions.cs
+++ b/src/Converter.Temperature/Extensions/To/ToFloatExtensions.cs
@@ -20,6 +20,7 @@
         /// </summary>
         /// <param name="input"> The value to be converted. </param>
         /// <param name="fractionalCount"> The count of fractional after the decimal point. </param>
+        /// <exception cref="ArgumentOutOfRangeException"> If fractional count is greater than 15. </exception>
         /// <returns>
         /// The Celsius <see langword="float"/> result.
         /// </returns>
@@ -33,6 +34,7 @@
         /// </summary>
         /// <param name="input"> The value to be converted. </param>
         /// <param name="fractionalCount"> The count of fractional after the decimal point. </param>
+        /// <exception cref="ArgumentOutOfRangeException"> If fractional count is greater than 15. </exception>
         /// <returns>
         /// The Celsius <see langword="float"/> result.
         /// </returns>
@@ -46,7 +48,8 @@
         /// </summary>
         /// <param name="input"> The value to be converted. </param>
         /// <param name="fractionalCount"> The count of fractional after the decimal point. </param>
-        /// <exception cref="T:System.ArgumentOutOfRangeException">Temp too low or too high for gas mark!</exception>
+        /// <exception cref="ArgumentOutOfRangeException">Temp too low or too high for gas mark!</exception>
+        /// <exception cref="ArgumentOutOfRangeException"> If fractional count is greater than 15. </exception>
         /// <returns>
         /// The Celsius <see langword="float"/> result.
         /// </returns>
@@ -60,6 +63,7 @@
         /// </summary>
         /// <param name="input"> The value to be converted. </param>
         /// <param name="fractionalCount"> The count of fractional after the decimal point. </param>
+        /// <exception cref="ArgumentOutOfRangeException"> If fractional count is greater than 15. </exception>
         /// <returns>
         /// The Celsius <see langword="float"/> result.
         /// </returns>
@@ -73,6 +77,7 @@
         /// </summary>
         /// <param name="input"> The value to be converted. </param>
         /// <param name="fractionalCount"> The count of fractional after the decimal point. </param>
+        /// <exception cref="ArgumentOutOfRangeException"> If fractional count is greater than 15. </exception>
         /// <returns>
         /// The Celsius <see langword="float"/> result.
         /// </returns>
@@ -86,7 +91,8 @@
         /// </summary>
         /// <param name="input"> The value to be converted. </param>
         /// <param name="fractionalCount"> The count of fractional after the decimal point. </param>
-        /// <exception cref="T:System.ArgumentOutOfRangeException">If calculated value is beyond the limits of the type.</exception>
+        /// <exception cref="ArgumentOutOfRangeException"> If calculated value is beyond the limits of the type. </exception>
+        /// <exception cref="ArgumentOutOfRangeException"> If fractional count is greater than 15. </exception>
         /// <returns>
         /// The FahrenheitConverter <see langword="float"/> result.
         /// </returns>
@@ -113,7 +119,8 @@
         /// </summary>
         /// <param name="input"> The value to be converted. </param>
         /// <param name="fractionalCount"> The count of fractional after the decimal point. </param>
-        /// <exception cref="T:System.ArgumentOutOfRangeException">Temp too low or too high for gas mark!</exception>
+        /// <exception cref="ArgumentOutOfRangeException"> Temp too low or too high for gas mark! </exception>
+        /// <exception cref="ArgumentOutOfRangeException"> If fractional count is greater than 15. </exception>
         /// <returns>
         /// The FahrenheitConverter <see langword="float"/> result.
         /// </returns>
@@ -127,7 +134,8 @@
         /// </summary>
         /// <param name="input"> The value to be converted. </param>
         /// <param name="fractionalCount"> The count of fractional after the decimal point. </param>
-        /// <exception cref="T:System.ArgumentOutOfRangeException">If calculated value is beyond the limits of the type.</exception>
+        /// <exception cref="ArgumentOutOfRangeException"> If calculated value is beyond the limits of the type. </exception>
+        /// <exception cref="ArgumentOutOfRangeException"> If fractional count is greater than 15. </exception>
         /// <returns>
         /// The FahrenheitConverter <see langword="float"/> result.
         /// </returns>
@@ -141,6 +149,7 @@
         /// </summary>
         /// <param name="input"> The value to be converted. </param>
         /// <param name="fractionalCount"> The count of fractional after the decimal point. </param>
+        /// <exception cref="ArgumentOutOfRangeException"> If fractional count is greater than 15. </exception>
         /// <returns>
         /// The FahrenheitConverter <see langword="float"/> result.
         /// </returns>
@@ -154,7 +163,8 @@
         /// </summary>
         /// <param name="input"> The value to be converted. </param>
         /// <param name="fractionalCount"> The count of fractional after the decimal point. </param>
-        /// <exception cref="T:System.ArgumentOutOfRangeException">Temp too low or too high for gas mark!</exception>
+        /// <exception cref="ArgumentOutOfRangeException"> Temp too low or too high for gas mark! </exception>
+        /// <exception cref="ArgumentOutOfRangeException"> If fractional count is greater than 15. </exception>
         /// <returns>
         /// The GasConverter <see langword="float"/> result.
         /// </returns>
@@ -168,7 +178,8 @@
         /// </summary>
         /// <param name="input"> The value to be converted. </param>
         /// <param name="fractionalCount"> The count of fractional after the decimal point. </param>
-        /// <exception cref="T:System.ArgumentOutOfRangeException">Temp too low or too high for gas mark!</exception>
+        /// <exception cref="ArgumentOutOfRangeException"> Temp too low or too high for gas mark! </exception>
+        /// <exception cref="ArgumentOutOfRangeException"> If fractional count is greater than 15. </exception>
         /// <returns>
         /// The GasConverter <see langword="float"/> result.
         /// </returns>
@@ -182,7 +193,8 @@
         /// </summary>
         /// <param name="input"> The value to be converted. </param>
         /// <param name="fractionalCount"> The count of fractional after the decimal point. </param>
-        /// <exception cref="T:System.ArgumentOutOfRangeException">Temp too low or too high for gas mark!</exception>
+        /// <exception cref="ArgumentOutOfRangeException"> Temp too low or too high for gas mark! </exception>
+        /// <exception cref="ArgumentOutOfRangeException"> If fractional count is greater than 15. </exception>
         /// <returns>
         /// The GasConverter <see langword="float"/> result.
         /// </returns>
@@ -196,7 +208,8 @@
         /// </summary>
         /// <param name="input"> The value to be converted. </param>
         /// <param name="fractionalCount"> The count of fractional after the decimal point. </param>
-        /// <exception cref="T:System.ArgumentOutOfRangeException">Temp too low or too high for gas mark!</exception>
+        /// <exception cref="ArgumentOutOfRangeException"> Temp too low or too high for gas mark! </exception>
+        /// <exception cref="ArgumentOutOfRangeException"> If fractional count is greater than 15. </exception>
         /// <returns>
         /// The GasConverter <see langword="float"/> result.
         /// </returns>
@@ -210,7 +223,8 @@
         /// </summary>
         /// <param name="input"> The value to be converted. </param>
         /// <param name="fractionalCount"> The count of fractional after the decimal point. </param>
-        /// <exception cref="T:System.ArgumentOutOfRangeException">Temp too low or too high for gas mark!</exception>
+        /// <exception cref="ArgumentOutOfRangeException"> Temp too low or too high for gas mark! </exception>
+        /// <exception cref="ArgumentOutOfRangeException"> If fractional count is greater than 15. </exception>
         /// <returns>
         /// The GasConverter <see langword="float"/> result.
         /// </returns>
@@ -224,7 +238,8 @@
         /// </summary>
         /// <param name="input"> The value to be converted. </param>
         /// <param name="fractionalCount"> The count of fractional after the decimal point. </param>
-        /// <exception cref="T:System.ArgumentOutOfRangeException">If calculated value is beyond the limits of the type.</exception>
+        /// <exception cref="ArgumentOutOfRangeException"> If calculated value is beyond the limits of the type. </exception>
+        /// <exception cref="ArgumentOutOfRangeException"> If fractional count is greater than 15. </exception>
         /// <returns>
         /// The KelvinConverter <see langword="float"/> result.
         /// </returns>
@@ -238,7 +253,8 @@
         /// </summary>
         /// <param name="input"> The value to be converted. </param>
         /// <param name="fractionalCount"> The count of fractional after the decimal point. </param>
-        /// <exception cref="T:System.ArgumentOutOfRangeException">If calculated value is beyond the limits of the type.</exception>
+        /// <exception cref="ArgumentOutOfRangeException"> If calculated value is beyond the limits of the type. </exception>
+        /// <exception cref="ArgumentOutOfRangeException"> If fractional count is greater than 15. </exception>
         /// <returns>
         /// The KelvinConverter <see langword="float"/> result.
         /// </returns>
@@ -252,7 +268,8 @@
         /// </summary>
         /// <param name="input"> The value to be converted. </param>
         /// <param name="fractionalCount"> The count of fractional after the decimal point. </param>
-        /// <exception cref="T:System.ArgumentOutOfRangeException">Temp too low or too high for gas mark!</exception>
+        /// <exception cref="ArgumentOutOfRangeException"> Temp too low or too high for gas mark! </exception>
+        /// <exception cref="ArgumentOutOfRangeException"> If fractional count is greater than 15. </exception>
         /// <returns>
         /// The KelvinConverter <see langword="float"/> result.
         /// </returns>
@@ -266,6 +283,7 @@
         /// </summary>
         /// <param name="input"> The value to be converted. </param>
         /// <param name="fractionalCount"> The count of fractional after the decimal point. </param>
+        /// <exception cref="ArgumentOutOfRangeException"> If fractional count is greater than 15. </exception>
         /// <returns>
         /// The KelvinConverter <see langword="float"/> result.
         /// </returns>
@@ -279,9 +297,8 @@
         /// </summary>
         /// <param name="input"> The value to be converted. </param>
         /// <param name="fractionalCount"> The count of fractional after the decimal point. </param>
-        /// <exception cref="ArgumentOutOfRangeException">
-        /// If calculated value is beyond the limits of the type.
-        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException"> If calculated value is beyond the limits of the type. </exception>
+        /// <exception cref="ArgumentOutOfRangeException"> If fractional count is greater than 15. </exception>
         /// <returns>
         /// The KelvinConverter <see langword="float"/> result.
         /// </returns>
@@ -295,7 +312,8 @@
         /// </summary>
         /// <param name="input"> The value to be converted. </param>
         /// <param name="fractionalCount"> The count of fractional after the decimal point. </param>
-        /// <exception cref="T:System.ArgumentOutOfRangeException">If calculated value is beyond the limits of the type.</exception>
+        /// <exception cref="ArgumentOutOfRangeException"> If calculated value is beyond the limits of the type. </exception>
+        /// <exception cref="ArgumentOutOfRangeException"> If fractional count is greater than 15. </exception>
         /// <returns>
         /// The RankineConverter <see langword="float"/> result.
         /// </returns>
@@ -309,7 +327,8 @@
         /// </summary>
         /// <param name="input"> The value to be converted. </param>
         /// <param name="fractionalCount"> The count of fractional after the decimal point. </param>
-        /// <exception cref="T:System.ArgumentOutOfRangeException">If calculated value is beyond the limits of the type.</exception>
+        /// <exception cref="ArgumentOutOfRangeException"> If calculated value is beyond the limits of the type. </exception>
+        /// <exception cref="ArgumentOutOfRangeException"> If fractional count is greater than 15. </exception>
         /// <returns>
         /// The RankineConverter <see langword="float"/> result.
         /// </returns>
@@ -323,7 +342,8 @@
         /// </summary>
         /// <param name="input"> The value to be converted. </param>
         /// <param name="fractionalCount"> The count of fractional after the decimal point. </param>
-        /// <exception cref="T:System.ArgumentOutOfRangeException">Temp too low or too high for gas mark!</exception>
+        /// <exception cref="ArgumentOutOfRangeException"> Temp too low or too high for gas mark! </exception>
+        /// <exception cref="ArgumentOutOfRangeException"> If fractional count is greater than 15. </exception>
         /// <returns>
         /// The RankineConverter <see langword="float"/> result.
         /// </returns>
@@ -337,7 +357,8 @@
         /// </summary>
         /// <param name="input"> The value to be converted. </param>
         /// <param name="fractionalCount"> The count of fractional after the decimal point. </param>
-        /// <exception cref="T:System.ArgumentOutOfRangeException">If calculated value is beyond the limits of the type.</exception>
+        /// <exception cref="ArgumentOutOfRangeException"> If calculated value is beyond the limits of the type. </exception>
+        /// <exception cref="ArgumentOutOfRangeException"> If fractional count is greater than 15. </exception>
         /// <returns>
         /// The RankineConverter <see langword="float"/> result.
         /// </returns>
@@ -351,6 +372,7 @@
         /// </summary>
         /// <param name="input"> The value to be converted. </param>
         /// <param name="fractionalCount"> The count of fractional after the decimal point. </param>
+        /// <exception cref="ArgumentOutOfRangeException"> If fractional count is greater than 15. </exception>
         /// <returns>
         /// The RankineConverter <see langword="float"/> result.
         /// </returns>
@@ -366,6 +388,7 @@
         /// <param name="input"> The value to be converted. </param>
         /// <param name="fractionalCount"> The count of fractional after the decimal point. </param>
         /// <exception cref="ArgumentException"> The TInput type is not a valid type for this method. </exception>
+        /// <exception cref="ArgumentOutOfRangeException"> If fractional count is greater than 15. </exception>
         /// <returns>
         /// The result of the conversion.
         /// </returns>

--- a/src/Converter.Temperature/Extensions/To/ToIntExtensions.cs
+++ b/src/Converter.Temperature/Extensions/To/ToIntExtensions.cs
@@ -31,7 +31,7 @@
         /// Converts the FahrenheitConverter <paramref name="input"/> to Celsius
         /// </summary>
         /// <param name="input"> The value to be converted. </param>
-        /// <exception cref="T:System.ArgumentOutOfRangeException"> If calculated value is beyond the limits of the type. </exception>
+        /// <exception cref="ArgumentOutOfRangeException"> If calculated value is beyond the limits of the type. </exception>
         /// <returns>
         /// The Celsius <see langword="int"/> result.
         /// </returns>
@@ -44,7 +44,7 @@
         /// Converts the GasConverter <paramref name="input"/> to Celsius
         /// </summary>
         /// <param name="input"> The value to be converted. </param>
-        /// <exception cref="T:System.ArgumentOutOfRangeException">Temp too low or too high for gas mark!</exception>
+        /// <exception cref="ArgumentOutOfRangeException"> Temp too low or too high for gas mark! </exception>
         /// <returns>
         /// The Celsius <see langword="int"/> result.
         /// </returns>
@@ -57,7 +57,7 @@
         /// Converts the KelvinConverter <paramref name="input"/> to Celsius
         /// </summary>
         /// <param name="input"> The value to be converted. </param>
-        /// <exception cref="T:System.ArgumentOutOfRangeException"> If calculated value is beyond the limits of the type. </exception>
+        /// <exception cref="ArgumentOutOfRangeException"> If calculated value is beyond the limits of the type. </exception>
         /// <returns>
         /// The Celsius <see langword="int"/> result.
         /// </returns>
@@ -70,7 +70,7 @@
         /// Converts the RankineConverter <paramref name="input"/> to Celsius
         /// </summary>
         /// <param name="input"> The value to be converted. </param>
-        /// <exception cref="T:System.ArgumentOutOfRangeException"> If calculated value is beyond the limits of the type. </exception>
+        /// <exception cref="ArgumentOutOfRangeException"> If calculated value is beyond the limits of the type. </exception>
         /// <returns>
         /// The Celsius <see langword="int"/> result.
         /// </returns>
@@ -83,7 +83,7 @@
         /// Converts the Celsius <paramref name="input"/> to FahrenheitConverter
         /// </summary>
         /// <param name="input"> The value to be converted. </param>
-        /// <exception cref="T:System.ArgumentOutOfRangeException">If calculated value is beyond the limits of the type.</exception>
+        /// <exception cref="ArgumentOutOfRangeException"> If calculated value is beyond the limits of the type. </exception>
         /// <returns>
         /// The FahrenheitConverter <see langword="int"/> result.
         /// </returns>
@@ -108,7 +108,7 @@
         /// Converts the GasConverter <paramref name="input"/> to FahrenheitConverter
         /// </summary>
         /// <param name="input"> The value to be converted. </param>
-        /// <exception cref="T:System.ArgumentOutOfRangeException">Temp too low or too high for gas mark!</exception>
+        /// <exception cref="ArgumentOutOfRangeException"> Temp too low or too high for gas mark! </exception>
         /// <returns>
         /// The FahrenheitConverter <see langword="int"/> result.
         /// </returns>
@@ -121,7 +121,7 @@
         /// Converts the KelvinConverter <paramref name="input"/> to FahrenheitConverter
         /// </summary>
         /// <param name="input"> The value to be converted. </param>
-        /// <exception cref="T:System.ArgumentOutOfRangeException">If calculated value is beyond the limits of the type.</exception>
+        /// <exception cref="ArgumentOutOfRangeException"> If calculated value is beyond the limits of the type. </exception>
         /// <returns>
         /// The FahrenheitConverter <see langword="int"/> result.
         /// </returns>
@@ -134,7 +134,7 @@
         /// Converts the RankineConverter <paramref name="input"/> to FahrenheitConverter
         /// </summary>
         /// <param name="input"> The value to be converted. </param>
-        /// <exception cref="T:System.ArgumentOutOfRangeException">If calculated value is beyond the limits of the type.</exception>
+        /// <exception cref="ArgumentOutOfRangeException"> If calculated value is beyond the limits of the type. </exception>
         /// <returns>
         /// The FahrenheitConverter <see langword="int"/> result.
         /// </returns>
@@ -147,7 +147,7 @@
         /// Converts the Celsius <paramref name="input"/> to GasConverter
         /// </summary>
         /// <param name="input"> The value to be converted. </param>
-        /// <exception cref="T:System.ArgumentOutOfRangeException">Temp too low or too high for gas mark!</exception>
+        /// <exception cref="ArgumentOutOfRangeException"> Temp too low or too high for gas mark! </exception>
         /// <returns>
         /// The GasConverter <see langword="int"/> result.
         /// </returns>
@@ -160,7 +160,7 @@
         /// Converts the FahrenheitConverter <paramref name="input"/> to GasConverter
         /// </summary>
         /// <param name="input"> The value to be converted. </param>
-        /// <exception cref="T:System.ArgumentOutOfRangeException">Temp too low or too high for gas mark!</exception>
+        /// <exception cref="ArgumentOutOfRangeException"> Temp too low or too high for gas mark! </exception>
         /// <returns>
         /// The GasConverter <see langword="int"/> result.
         /// </returns>
@@ -173,7 +173,7 @@
         /// Converts the GasConverter <paramref name="input"/> to GasConverter
         /// </summary>
         /// <param name="input"> The value to be converted. </param>
-        /// <exception cref="T:System.ArgumentOutOfRangeException">Temp too low or too high for gas mark!</exception>
+        /// <exception cref="ArgumentOutOfRangeException"> Temp too low or too high for gas mark! </exception>
         /// <returns>
         /// The GasConverter <see langword="int"/> result.
         /// </returns>
@@ -186,7 +186,7 @@
         /// Converts the KelvinConverter <paramref name="input"/> to GasConverter
         /// </summary>
         /// <param name="input"> The value to be converted. </param>
-        /// <exception cref="T:System.ArgumentOutOfRangeException">Temp too low or too high for gas mark!</exception>
+        /// <exception cref="ArgumentOutOfRangeException"> Temp too low or too high for gas mark! </exception>
         /// <returns>
         /// The GasConverter <see langword="int"/> result.
         /// </returns>
@@ -199,7 +199,7 @@
         /// Converts the RankineConverter <paramref name="input"/> to GasConverter
         /// </summary>
         /// <param name="input"> The value to be converted. </param>
-        /// <exception cref="T:System.ArgumentOutOfRangeException">Temp too low or too high for gas mark!</exception>
+        /// <exception cref="ArgumentOutOfRangeException"> Temp too low or too high for gas mark! </exception>
         /// <returns>
         /// The GasConverter <see langword="int"/> result.
         /// </returns>
@@ -212,7 +212,7 @@
         /// Converts the Celsius <paramref name="input"/> to KelvinConverter
         /// </summary>
         /// <param name="input"> The value to be converted. </param>
-        /// <exception cref="T:System.ArgumentOutOfRangeException">If calculated value is beyond the limits of the type.</exception>
+        /// <exception cref="ArgumentOutOfRangeException"> If calculated value is beyond the limits of the type. </exception>
         /// <returns>
         /// The KelvinConverter <see langword="int"/> result.
         /// </returns>
@@ -225,7 +225,7 @@
         /// Converts the FahrenheitConverter <paramref name="input"/> to KelvinConverter
         /// </summary>
         /// <param name="input"> The value to be converted. </param>
-        /// <exception cref="T:System.ArgumentOutOfRangeException">If calculated value is beyond the limits of the type.</exception>
+        /// <exception cref="ArgumentOutOfRangeException"> If calculated value is beyond the limits of the type. </exception>
         /// <returns>
         /// The KelvinConverter <see langword="int"/> result.
         /// </returns>
@@ -238,7 +238,7 @@
         /// Converts the GasConverter <paramref name="input"/> to KelvinConverter
         /// </summary>
         /// <param name="input"> The value to be converted. </param>
-        /// <exception cref="T:System.ArgumentOutOfRangeException">Temp too low or too high for gas mark!</exception>
+        /// <exception cref="ArgumentOutOfRangeException"> Temp too low or too high for gas mark! </exception>
         /// <returns>
         /// The KelvinConverter <see langword="int"/> result.
         /// </returns>
@@ -275,7 +275,7 @@
         /// Converts the Celsius <paramref name="input"/> to RankineConverter
         /// </summary>
         /// <param name="input"> The value to be converted. </param>
-        /// <exception cref="T:System.ArgumentOutOfRangeException">If calculated value is beyond the limits of the type.</exception>
+        /// <exception cref="ArgumentOutOfRangeException"> If calculated value is beyond the limits of the type. </exception>
         /// <returns>
         /// The RankineConverter <see langword="int"/> result.
         /// </returns>
@@ -288,7 +288,7 @@
         /// Converts the FahrenheitConverter <paramref name="input"/> to RankineConverter
         /// </summary>
         /// <param name="input"> The value to be converted. </param>
-        /// <exception cref="T:System.ArgumentOutOfRangeException">If calculated value is beyond the limits of the type.</exception>
+        /// <exception cref="ArgumentOutOfRangeException"> If calculated value is beyond the limits of the type. </exception>
         /// <returns>
         /// The RankineConverter <see langword="int"/> result.
         /// </returns>
@@ -301,7 +301,7 @@
         /// Converts the GasConverter <paramref name="input"/> to RankineConverter
         /// </summary>
         /// <param name="input"> The value to be converted. </param>
-        /// <exception cref="T:System.ArgumentOutOfRangeException">Temp too low or too high for gas mark!</exception>
+        /// <exception cref="ArgumentOutOfRangeException"> Temp too low or too high for gas mark! </exception>
         /// <returns>
         /// The RankineConverter <see langword="int"/> result.
         /// </returns>

--- a/src/Converter.Temperature/Extensions/To/ToStringExtensions.cs
+++ b/src/Converter.Temperature/Extensions/To/ToStringExtensions.cs
@@ -19,316 +19,366 @@
         /// Converts the Celsius <paramref name="input"/> to Celsius
         /// </summary>
         /// <param name="input"> The value to be converted. </param>
+        /// <param name="fractionalCount"> The count of fractional after the decimal point. </param>
+        /// <exception cref="ArgumentOutOfRangeException"> If fractional count is greater than 15. </exception>
         /// <returns>
         /// The Celsius string result.
         /// </returns>
-        public static string ToCelsius(this CelsiusString input)
+        public static string ToCelsius(this CelsiusString input, int fractionalCount = -1)
         {
-            return StringParser(input.Temperature, CelsiusConverter.CelsiusToCelsius);
+            return Parser(input.Temperature, CelsiusConverter.CelsiusToCelsius, fractionalCount);
         }
 
         /// <summary>
         /// Converts the FahrenheitConverter <paramref name="input"/> to Celsius
         /// </summary>
         /// <param name="input"> The value to be converted. </param>
+        /// <param name="fractionalCount"> The count of fractional after the decimal point. </param>
+        /// <exception cref="ArgumentOutOfRangeException"> If fractional count is greater than 15. </exception>
         /// <returns>
         /// The Celsius string result.
         /// </returns>
-        public static string ToCelsius(this FahrenheitString input)
+        public static string ToCelsius(this FahrenheitString input, int fractionalCount = -1)
         {
-            return StringParser(input.Temperature, FahrenheitConverter.FahrenheitToCelsius);
+            return Parser(input.Temperature, FahrenheitConverter.FahrenheitToCelsius, fractionalCount);
         }
 
         /// <summary>
         /// Converts the GasConverter <paramref name="input"/> to Celsius
         /// </summary>
         /// <param name="input"> The value to be converted. </param>
-        /// <exception cref="T:System.ArgumentOutOfRangeException">Temp too low or too high for gas mark!</exception>
+        /// <param name="fractionalCount"> The count of fractional after the decimal point. </param>
+        /// <exception cref="ArgumentOutOfRangeException"> Temp too low or too high for gas mark! </exception>
+        /// <exception cref="ArgumentOutOfRangeException"> If fractional count is greater than 15. </exception>
         /// <returns>
         /// The Celsius string result.
         /// </returns>
-        public static string ToCelsius(this GasString input)
+        public static string ToCelsius(this GasString input, int fractionalCount = -1)
         {
-            return StringParser(input.Temperature, GasConverter.GasToCelsius);
+            return Parser(input.Temperature, GasConverter.GasToCelsius, fractionalCount);
         }
 
         /// <summary>
         /// Converts the KelvinConverter <paramref name="input"/> to Celsius
         /// </summary>
         /// <param name="input"> The value to be converted. </param>
+        /// <param name="fractionalCount"> The count of fractional after the decimal point. </param>
+        /// <exception cref="ArgumentOutOfRangeException"> If fractional count is greater than 15. </exception>
         /// <returns>
         /// The Celsius string result.
         /// </returns>
-        public static string ToCelsius(this KelvinString input)
+        public static string ToCelsius(this KelvinString input, int fractionalCount = -1)
         {
-            return StringParser(input.Temperature, KelvinConverter.KelvinToCelsius);
+            return Parser(input.Temperature, KelvinConverter.KelvinToCelsius, fractionalCount);
         }
 
         /// <summary>
         /// Converts the RankineConverter <paramref name="input"/> to Celsius
         /// </summary>
         /// <param name="input"> The value to be converted. </param>
+        /// <param name="fractionalCount"> The count of fractional after the decimal point. </param>
+        /// <exception cref="ArgumentOutOfRangeException"> If fractional count is greater than 15. </exception>
         /// <returns>
         /// The Celsius string result.
         /// </returns>
-        public static string ToCelsius(this RankineString input)
+        public static string ToCelsius(this RankineString input, int fractionalCount = -1)
         {
-            return StringParser(input.Temperature, RankineConverter.RankineToCelsius);
+            return Parser(input.Temperature, RankineConverter.RankineToCelsius, fractionalCount);
         }
 
         /// <summary>
         /// Converts the Celsius <paramref name="input"/> to FahrenheitConverter
         /// </summary>
         /// <param name="input"> The value to be converted. </param>
-        /// <exception cref="T:System.ArgumentOutOfRangeException">If calculated value is beyond the limits of the type.</exception>
+        /// <param name="fractionalCount"> The count of fractional after the decimal point. </param>
+        /// <exception cref="ArgumentOutOfRangeException"> If calculated value is beyond the limits of the type. </exception>
+        /// <exception cref="ArgumentOutOfRangeException"> If fractional count is greater than 15. </exception>
         /// <returns>
         /// The FahrenheitConverter string result.
         /// </returns>
-        public static string ToFahrenheit(this CelsiusString input)
+        public static string ToFahrenheit(this CelsiusString input, int fractionalCount = -1)
         {
-            return StringParser(input.Temperature, CelsiusConverter.CelsiusToFahrenheit);
+            return Parser(input.Temperature, CelsiusConverter.CelsiusToFahrenheit, fractionalCount);
         }
 
         /// <summary>
         /// Converts the FahrenheitConverter <paramref name="input"/> to FahrenheitConverter
         /// </summary>
         /// <param name="input"> The value to be converted. </param>
+        /// <param name="fractionalCount"> The count of fractional after the decimal point. </param>
+        /// <exception cref="ArgumentOutOfRangeException"> If fractional count is greater than 15. </exception>
         /// <returns>
         /// The FahrenheitConverter string result.
         /// </returns>
-        public static string ToFahrenheit(this FahrenheitString input)
+        public static string ToFahrenheit(this FahrenheitString input, int fractionalCount = -1)
         {
-            return StringParser(input.Temperature, FahrenheitConverter.FahrenheitToFahrenheit);
+            return Parser(input.Temperature, FahrenheitConverter.FahrenheitToFahrenheit, fractionalCount);
         }
 
         /// <summary>
         /// Converts the GasConverter <paramref name="input"/> to FahrenheitConverter
         /// </summary>
         /// <param name="input"> The value to be converted. </param>
-        /// <exception cref="T:System.ArgumentOutOfRangeException">Temp too low or too high for gas mark!</exception>
+        /// <param name="fractionalCount"> The count of fractional after the decimal point. </param>
+        /// <exception cref="ArgumentOutOfRangeException"> Temp too low or too high for gas mark! </exception>
+        /// <exception cref="ArgumentOutOfRangeException"> If fractional count is greater than 15. </exception>
         /// <returns>
         /// The FahrenheitConverter string result.
         /// </returns>
-        public static string ToFahrenheit(this GasString input)
+        public static string ToFahrenheit(this GasString input, int fractionalCount = -1)
         {
-            return StringParser(input.Temperature, GasConverter.GasToFahrenheit);
+            return Parser(input.Temperature, GasConverter.GasToFahrenheit, fractionalCount);
         }
 
         /// <summary>
         /// Converts the KelvinConverter <paramref name="input"/> to FahrenheitConverter
         /// </summary>
         /// <param name="input"> The value to be converted. </param>
-        /// <exception cref="T:System.ArgumentOutOfRangeException">If calculated value is beyond the limits of the type.</exception>
+        /// <param name="fractionalCount"> The count of fractional after the decimal point. </param>
+        /// <exception cref="ArgumentOutOfRangeException"> If calculated value is beyond the limits of the type. </exception>
+        /// <exception cref="ArgumentOutOfRangeException"> If fractional count is greater than 15. </exception>
         /// <returns>
         /// The FahrenheitConverter string result.
         /// </returns>
-        public static string ToFahrenheit(this KelvinString input)
+        public static string ToFahrenheit(this KelvinString input, int fractionalCount = -1)
         {
-            return StringParser(input.Temperature, KelvinConverter.KelvinToFahrenheit);
+            return Parser(input.Temperature, KelvinConverter.KelvinToFahrenheit, fractionalCount);
         }
 
         /// <summary>
         /// Converts the RankineConverter <paramref name="input"/> to FahrenheitConverter
         /// </summary>
         /// <param name="input"> The value to be converted. </param>
-        /// <exception cref="T:System.ArgumentOutOfRangeException">If calculated value is beyond the limits of the type.</exception>
+        /// <param name="fractionalCount"> The count of fractional after the decimal point. </param>
+        /// <exception cref="ArgumentOutOfRangeException"> If calculated value is beyond the limits of the type. </exception>
+        /// <exception cref="ArgumentOutOfRangeException"> If fractional count is greater than 15. </exception>
         /// <returns>
         /// The FahrenheitConverter string result.
         /// </returns>
-        public static string ToFahrenheit(this RankineString input)
+        public static string ToFahrenheit(this RankineString input, int fractionalCount = -1)
         {
-            return StringParser(input.Temperature, RankineConverter.RankineToFahrenheit);
+            return Parser(input.Temperature, RankineConverter.RankineToFahrenheit, fractionalCount);
         }
 
         /// <summary>
         /// Converts the Celsius <paramref name="input"/> to GasConverter
         /// </summary>
         /// <param name="input"> The value to be converted. </param>
-        /// <exception cref="T:System.ArgumentOutOfRangeException">Temp too low or too high for gas mark!</exception>
+        /// <param name="fractionalCount"> The count of fractional after the decimal point. </param>
+        /// <exception cref="ArgumentOutOfRangeException"> Temp too low or too high for gas mark! </exception>
+        /// <exception cref="ArgumentOutOfRangeException"> If fractional count is greater than 15. </exception>
         /// <returns>
         /// The GasConverter string result.
         /// </returns>
-        public static string ToGas(this CelsiusString input)
+        public static string ToGas(this CelsiusString input, int fractionalCount = -1)
         {
-            return StringParser(input.Temperature, CelsiusConverter.CelsiusToGas);
+            return Parser(input.Temperature, CelsiusConverter.CelsiusToGas, fractionalCount);
         }
 
         /// <summary>
         /// Converts the FahrenheitConverter <paramref name="input"/> to GasConverter
         /// </summary>
         /// <param name="input"> The value to be converted. </param>
-        /// <exception cref="T:System.ArgumentOutOfRangeException">Temp too low or too high for gas mark!</exception>
+        /// <param name="fractionalCount"> The count of fractional after the decimal point. </param>
+        /// <exception cref="ArgumentOutOfRangeException"> Temp too low or too high for gas mark! </exception>
+        /// <exception cref="ArgumentOutOfRangeException"> If fractional count is greater than 15. </exception>
         /// <returns>
         /// The GasConverter string result.
         /// </returns>
-        public static string ToGas(this FahrenheitString input)
+        public static string ToGas(this FahrenheitString input, int fractionalCount = -1)
         {
-            return StringParser(input.Temperature, FahrenheitConverter.FahrenheitToGas);
+            return Parser(input.Temperature, FahrenheitConverter.FahrenheitToGas, fractionalCount);
         }
 
         /// <summary>
         /// Converts the GasConverter <paramref name="input"/> to GasConverter
         /// </summary>
         /// <param name="input"> The value to be converted. </param>
-        /// <exception cref="T:System.ArgumentOutOfRangeException">Temp too low or too high for gas mark!</exception>
+        /// <param name="fractionalCount"> The count of fractional after the decimal point. </param>
+        /// <exception cref="ArgumentOutOfRangeException"> Temp too low or too high for gas mark! </exception>
+        /// <exception cref="ArgumentOutOfRangeException"> If fractional count is greater than 15. </exception>
         /// <returns>
         /// The GasConverter string result.
         /// </returns>
-        public static string ToGas(this GasString input)
+        public static string ToGas(this GasString input, int fractionalCount = -1)
         {
-            return StringParser(input.Temperature, GasConverter.GasToGas);
+            return Parser(input.Temperature, GasConverter.GasToGas, fractionalCount);
         }
 
         /// <summary>
         /// Converts the KelvinConverter <paramref name="input"/> to GasConverter
         /// </summary>
         /// <param name="input"> The value to be converted. </param>
-        /// <exception cref="T:System.ArgumentOutOfRangeException">Temp too low or too high for gas mark!</exception>
+        /// <param name="fractionalCount"> The count of fractional after the decimal point. </param>
+        /// <exception cref="ArgumentOutOfRangeException"> Temp too low or too high for gas mark! </exception>
+        /// <exception cref="ArgumentOutOfRangeException"> If fractional count is greater than 15. </exception>
         /// <returns>
         /// The GasConverter string result.
         /// </returns>
-        public static string ToGas(this KelvinString input)
+        public static string ToGas(this KelvinString input, int fractionalCount = -1)
         {
-            return StringParser(input.Temperature, KelvinConverter.KelvinToGas);
+            return Parser(input.Temperature, KelvinConverter.KelvinToGas, fractionalCount);
         }
 
         /// <summary>
         /// Converts the RankineConverter <paramref name="input"/> to GasConverter
         /// </summary>
         /// <param name="input"> The value to be converted. </param>
-        /// <exception cref="T:System.ArgumentOutOfRangeException">Temp too low or too high for gas mark!</exception>
+        /// <param name="fractionalCount"> The count of fractional after the decimal point. </param>
+        /// <exception cref="ArgumentOutOfRangeException"> Temp too low or too high for gas mark! </exception>
+        /// <exception cref="ArgumentOutOfRangeException"> If fractional count is greater than 15. </exception>
         /// <returns>
         /// The GasConverter string result.
         /// </returns>
-        public static string ToGas(this RankineString input)
+        public static string ToGas(this RankineString input, int fractionalCount = -1)
         {
-            return StringParser(input.Temperature, RankineConverter.RankineToGas);
+            return Parser(input.Temperature, RankineConverter.RankineToGas, fractionalCount);
         }
 
         /// <summary>
         /// Converts the Celsius <paramref name="input"/> to KelvinConverter
         /// </summary>
         /// <param name="input"> The value to be converted. </param>
-        /// <exception cref="T:System.ArgumentOutOfRangeException">If calculated value is beyond the limits of the type.</exception>
+        /// <param name="fractionalCount"> The count of fractional after the decimal point. </param>
+        /// <exception cref="ArgumentOutOfRangeException"> If calculated value is beyond the limits of the type. </exception>
+        /// <exception cref="ArgumentOutOfRangeException"> If fractional count is greater than 15. </exception>
         /// <returns>
         /// The KelvinConverter string result.
         /// </returns>
-        public static string ToKelvin(this CelsiusString input)
+        public static string ToKelvin(this CelsiusString input, int fractionalCount = -1)
         {
-            return StringParser(input.Temperature, CelsiusConverter.CelsiusToKelvin);
+            return Parser(input.Temperature, CelsiusConverter.CelsiusToKelvin, fractionalCount);
         }
 
         /// <summary>
         /// Converts the FahrenheitConverter <paramref name="input"/> to KelvinConverter
         /// </summary>
         /// <param name="input"> The value to be converted. </param>
-        /// <exception cref="T:System.ArgumentOutOfRangeException">If calculated value is beyond the limits of the type.</exception>
+        /// <param name="fractionalCount"> The count of fractional after the decimal point. </param>
+        /// <exception cref="ArgumentOutOfRangeException"> If calculated value is beyond the limits of the type. </exception>
+        /// <exception cref="ArgumentOutOfRangeException"> If fractional count is greater than 15. </exception>
         /// <returns>
         /// The KelvinConverter string result.
         /// </returns>
-        public static string ToKelvin(this FahrenheitString input)
+        public static string ToKelvin(this FahrenheitString input, int fractionalCount = -1)
         {
-            return StringParser(input.Temperature, FahrenheitConverter.FahrenheitToKelvin);
+            return Parser(input.Temperature, FahrenheitConverter.FahrenheitToKelvin, fractionalCount);
         }
 
         /// <summary>
         /// Converts the GasConverter <paramref name="input"/> to KelvinConverter
         /// </summary>
         /// <param name="input"> The value to be converted. </param>
-        /// <exception cref="T:System.ArgumentOutOfRangeException">Temp too low or too high for gas mark!</exception>
+        /// <param name="fractionalCount"> The count of fractional after the decimal point. </param>
+        /// <exception cref="ArgumentOutOfRangeException"> Temp too low or too high for gas mark! </exception>
+        /// <exception cref="ArgumentOutOfRangeException"> If fractional count is greater than 15. </exception>
         /// <returns>
         /// The KelvinConverter string result.
         /// </returns>
-        public static string ToKelvin(this GasString input)
+        public static string ToKelvin(this GasString input, int fractionalCount = -1)
         {
-            return StringParser(input.Temperature, GasConverter.GasToKelvin);
+            return Parser(input.Temperature, GasConverter.GasToKelvin, fractionalCount);
         }
 
         /// <summary>
         /// Converts the KelvinConverter <paramref name="input"/> to KelvinConverter
         /// </summary>
         /// <param name="input"> The value to be converted. </param>
+        /// <param name="fractionalCount"> The count of fractional after the decimal point. </param>
+        /// <exception cref="ArgumentOutOfRangeException"> If fractional count is greater than 15. </exception>
         /// <returns>
         /// The KelvinConverter string result.
         /// </returns>
-        public static string ToKelvin(this KelvinString input)
+        public static string ToKelvin(this KelvinString input, int fractionalCount = -1)
         {
-            return StringParser(input.Temperature, KelvinConverter.KelvinToKelvin);
+            return Parser(input.Temperature, KelvinConverter.KelvinToKelvin, fractionalCount);
         }
 
         /// <summary>
         /// Converts the RankineConverter <paramref name="input"/> to KelvinConverter
         /// </summary>
         /// <param name="input"> The value to be converted. </param>
+        /// <param name="fractionalCount"> The count of fractional after the decimal point. </param>
+        /// <exception cref="ArgumentOutOfRangeException"> If fractional count is greater than 15. </exception>
         /// <returns>
         /// The KelvinConverter string result.
         /// </returns>
-        public static string ToKelvin(this RankineString input)
+        public static string ToKelvin(this RankineString input, int fractionalCount = -1)
         {
-            return StringParser(input.Temperature, RankineConverter.RankineToKelvin);
+            return Parser(input.Temperature, RankineConverter.RankineToKelvin, fractionalCount);
         }
 
         /// <summary>
         /// Converts the Celsius <paramref name="input"/> to RankineConverter
         /// </summary>
         /// <param name="input"> The value to be converted. </param>
-        /// <exception cref="T:System.ArgumentOutOfRangeException">If calculated value is beyond the limits of the type.</exception>
+        /// <param name="fractionalCount"> The count of fractional after the decimal point. </param>
+        /// <exception cref="ArgumentOutOfRangeException"> If calculated value is beyond the limits of the type. </exception>
+        /// <exception cref="ArgumentOutOfRangeException"> If fractional count is greater than 15. </exception>
         /// <returns>
         /// The RankineConverter string result.
         /// </returns>
-        public static string ToRankine(this CelsiusString input)
+        public static string ToRankine(this CelsiusString input, int fractionalCount = -1)
         {
-            return StringParser(input.Temperature, CelsiusConverter.CelsiusToRankine);
+            return Parser(input.Temperature, CelsiusConverter.CelsiusToRankine, fractionalCount);
         }
 
         /// <summary>
         /// Converts the FahrenheitConverter <paramref name="input"/> to RankineConverter
         /// </summary>
         /// <param name="input"> The value to be converted. </param>
-        /// <exception cref="T:System.ArgumentOutOfRangeException">If calculated value is beyond the limits of the type.</exception>
+        /// <param name="fractionalCount"> The count of fractional after the decimal point. </param>
+        /// <exception cref="ArgumentOutOfRangeException"> If calculated value is beyond the limits of the type. </exception>
+        /// <exception cref="ArgumentOutOfRangeException"> If fractional count is greater than 15. </exception>
         /// <returns>
         /// The RankineConverter string result.
         /// </returns>
-        public static string ToRankine(this FahrenheitString input)
+        public static string ToRankine(this FahrenheitString input, int fractionalCount = -1)
         {
-            return StringParser(input.Temperature, FahrenheitConverter.FahrenheitToRankine);
+            return Parser(input.Temperature, FahrenheitConverter.FahrenheitToRankine, fractionalCount);
         }
 
         /// <summary>
         /// Converts the GasConverter <paramref name="input"/> to RankineConverter
         /// </summary>
         /// <param name="input"> The value to be converted. </param>
-        /// <exception cref="T:System.ArgumentOutOfRangeException">Temp too low or too high for gas mark!</exception>
+        /// <param name="fractionalCount"> The count of fractional after the decimal point. </param>
+        /// <exception cref="ArgumentOutOfRangeException"> Temp too low or too high for gas mark! </exception>
+        /// <exception cref="ArgumentOutOfRangeException"> If fractional count is greater than 15. </exception>
         /// <returns>
         /// The RankineConverter string result.
         /// </returns>
-        public static string ToRankine(this GasString input)
+        public static string ToRankine(this GasString input, int fractionalCount = -1)
         {
-            return StringParser(input.Temperature, GasConverter.GasToRankine);
+            return Parser(input.Temperature, GasConverter.GasToRankine, fractionalCount);
         }
 
         /// <summary>
         /// Converts the KelvinConverter <paramref name="input"/> to RankineConverter
         /// </summary>
         /// <param name="input"> The value to be converted. </param>
+        /// <param name="fractionalCount"> The count of fractional after the decimal point. </param>
+        /// <exception cref="ArgumentOutOfRangeException"> If fractional count is greater than 15. </exception>
         /// <returns>
         /// The RankineConverter string result.
         /// </returns>
-        public static string ToRankine(this KelvinString input)
+        public static string ToRankine(this KelvinString input, int fractionalCount = -1)
         {
-            return StringParser(input.Temperature, KelvinConverter.KelvinToRankine);
+            return Parser(input.Temperature, KelvinConverter.KelvinToRankine, fractionalCount);
         }
 
         /// <summary>
         /// Converts the RankineConverter <paramref name="input"/> to RankineConverter
         /// </summary>
         /// <param name="input"> The value to be converted. </param>
+        /// <param name="fractionalCount"> The count of fractional after the decimal point. </param>
+        /// <exception cref="ArgumentOutOfRangeException"> If fractional count is greater than 15. </exception>
         /// <returns>
         /// The RankineConverter string result.
         /// </returns>
-        public static string ToRankine(this RankineString input)
+        public static string ToRankine(this RankineString input, int fractionalCount = -1)
         {
-            return StringParser(input.Temperature, RankineConverter.RankineToRankine);
+            return Parser(input.Temperature, RankineConverter.RankineToRankine, fractionalCount);
         }
 
         /// <summary>
@@ -336,53 +386,60 @@
         /// </summary>
         /// <typeparam name="TInput"> The temperature type to be converted to. </typeparam>
         /// <param name="input"> The value to be converted. </param>
+        /// <param name="fractionalCount"> The count of fractional after the decimal point. </param>
         /// <exception cref="ArgumentException"> The TInput type is not a valid type for this method. </exception>
+        /// <exception cref="ArgumentOutOfRangeException"> If fractional count is greater than 15. </exception>
         /// <returns>
         /// The result of the conversion.
         /// </returns>
-        public static string To<TInput>(this StringBase input)
+        public static string To<TInput>(this StringBase input, int fractionalCount = -1)
             where TInput : TemperatureBase
         {
             return typeof(TInput).Name switch
             {
-                nameof(Celsius) when input is CelsiusString castInput => StringParser(castInput.Temperature, CelsiusConverter.CelsiusToCelsius),
-                nameof(Celsius) when input is FahrenheitString castInput => StringParser(castInput.Temperature, FahrenheitConverter.FahrenheitToCelsius),
-                nameof(Celsius) when input is KelvinString castInput => StringParser(castInput.Temperature, KelvinConverter.KelvinToCelsius),
-                nameof(Celsius) when input is GasString castInput => StringParser(castInput.Temperature, GasConverter.GasToCelsius),
-                nameof(Celsius) when input is RankineString castInput => StringParser(castInput.Temperature, RankineConverter.RankineToCelsius),
-                nameof(Fahrenheit) when input is CelsiusString castInput => StringParser(castInput.Temperature, CelsiusConverter.CelsiusToFahrenheit),
-                nameof(Fahrenheit) when input is FahrenheitString castInput => StringParser(castInput.Temperature, FahrenheitConverter.FahrenheitToFahrenheit),
-                nameof(Fahrenheit) when input is KelvinString castInput => StringParser(castInput.Temperature, KelvinConverter.KelvinToFahrenheit),
-                nameof(Fahrenheit) when input is GasString castInput => StringParser(castInput.Temperature, GasConverter.GasToFahrenheit),
-                nameof(Fahrenheit) when input is RankineString castInput => StringParser(castInput.Temperature, RankineConverter.RankineToFahrenheit),
-                nameof(Kelvin) when input is CelsiusString castInput => StringParser(castInput.Temperature, CelsiusConverter.CelsiusToKelvin),
-                nameof(Kelvin) when input is FahrenheitString castInput => StringParser(castInput.Temperature, FahrenheitConverter.FahrenheitToKelvin),
-                nameof(Kelvin) when input is KelvinString castInput => StringParser(castInput.Temperature, KelvinConverter.KelvinToKelvin),
-                nameof(Kelvin) when input is GasString castInput => StringParser(castInput.Temperature, GasConverter.GasToKelvin),
-                nameof(Kelvin) when input is RankineString castInput => StringParser(castInput.Temperature, RankineConverter.RankineToKelvin),
-                nameof(Gas) when input is CelsiusString castInput => StringParser(castInput.Temperature, CelsiusConverter.CelsiusToGas),
-                nameof(Gas) when input is FahrenheitString castInput => StringParser(castInput.Temperature, FahrenheitConverter.FahrenheitToGas),
-                nameof(Gas) when input is KelvinString castInput => StringParser(castInput.Temperature, KelvinConverter.KelvinToGas),
-                nameof(Gas) when input is GasString castInput => StringParser(castInput.Temperature, GasConverter.GasToGas),
-                nameof(Gas) when input is RankineString castInput => StringParser(castInput.Temperature, RankineConverter.RankineToGas),
-                nameof(Rankine) when input is CelsiusString castInput => StringParser(castInput.Temperature, CelsiusConverter.CelsiusToRankine),
-                nameof(Rankine) when input is FahrenheitString castInput => StringParser(castInput.Temperature, FahrenheitConverter.FahrenheitToRankine),
-                nameof(Rankine) when input is KelvinString castInput => StringParser(castInput.Temperature, KelvinConverter.KelvinToRankine),
-                nameof(Rankine) when input is GasString castInput => StringParser(castInput.Temperature, GasConverter.GasToRankine),
-                nameof(Rankine) when input is RankineString castInput => StringParser(castInput.Temperature, RankineConverter.RankineToRankine),
+                nameof(Celsius) when input is CelsiusString castInput => Parser(castInput.Temperature, CelsiusConverter.CelsiusToCelsius, fractionalCount),
+                nameof(Celsius) when input is FahrenheitString castInput => Parser(castInput.Temperature, FahrenheitConverter.FahrenheitToCelsius, fractionalCount),
+                nameof(Celsius) when input is KelvinString castInput => Parser(castInput.Temperature, KelvinConverter.KelvinToCelsius, fractionalCount),
+                nameof(Celsius) when input is GasString castInput => Parser(castInput.Temperature, GasConverter.GasToCelsius, fractionalCount),
+                nameof(Celsius) when input is RankineString castInput => Parser(castInput.Temperature, RankineConverter.RankineToCelsius, fractionalCount),
+                nameof(Fahrenheit) when input is CelsiusString castInput => Parser(castInput.Temperature, CelsiusConverter.CelsiusToFahrenheit, fractionalCount),
+                nameof(Fahrenheit) when input is FahrenheitString castInput => Parser(castInput.Temperature, FahrenheitConverter.FahrenheitToFahrenheit, fractionalCount),
+                nameof(Fahrenheit) when input is KelvinString castInput => Parser(castInput.Temperature, KelvinConverter.KelvinToFahrenheit, fractionalCount),
+                nameof(Fahrenheit) when input is GasString castInput => Parser(castInput.Temperature, GasConverter.GasToFahrenheit, fractionalCount),
+                nameof(Fahrenheit) when input is RankineString castInput => Parser(castInput.Temperature, RankineConverter.RankineToFahrenheit, fractionalCount),
+                nameof(Kelvin) when input is CelsiusString castInput => Parser(castInput.Temperature, CelsiusConverter.CelsiusToKelvin, fractionalCount),
+                nameof(Kelvin) when input is FahrenheitString castInput => Parser(castInput.Temperature, FahrenheitConverter.FahrenheitToKelvin, fractionalCount),
+                nameof(Kelvin) when input is KelvinString castInput => Parser(castInput.Temperature, KelvinConverter.KelvinToKelvin, fractionalCount),
+                nameof(Kelvin) when input is GasString castInput => Parser(castInput.Temperature, GasConverter.GasToKelvin, fractionalCount),
+                nameof(Kelvin) when input is RankineString castInput => Parser(castInput.Temperature, RankineConverter.RankineToKelvin, fractionalCount),
+                nameof(Gas) when input is CelsiusString castInput => Parser(castInput.Temperature, CelsiusConverter.CelsiusToGas, fractionalCount),
+                nameof(Gas) when input is FahrenheitString castInput => Parser(castInput.Temperature, FahrenheitConverter.FahrenheitToGas, fractionalCount),
+                nameof(Gas) when input is KelvinString castInput => Parser(castInput.Temperature, KelvinConverter.KelvinToGas, fractionalCount),
+                nameof(Gas) when input is GasString castInput => Parser(castInput.Temperature, GasConverter.GasToGas, fractionalCount),
+                nameof(Gas) when input is RankineString castInput => Parser(castInput.Temperature, RankineConverter.RankineToGas, fractionalCount),
+                nameof(Rankine) when input is CelsiusString castInput => Parser(castInput.Temperature, CelsiusConverter.CelsiusToRankine, fractionalCount),
+                nameof(Rankine) when input is FahrenheitString castInput => Parser(castInput.Temperature, FahrenheitConverter.FahrenheitToRankine, fractionalCount),
+                nameof(Rankine) when input is KelvinString castInput => Parser(castInput.Temperature, KelvinConverter.KelvinToRankine, fractionalCount),
+                nameof(Rankine) when input is GasString castInput => Parser(castInput.Temperature, GasConverter.GasToRankine, fractionalCount),
+                nameof(Rankine) when input is RankineString castInput => Parser(castInput.Temperature, RankineConverter.RankineToRankine, fractionalCount),
                 _ => throw new ArgumentException($"Invalid type: {typeof(TInput).Name}")
             };
         }
 
-        private static string StringParser(string temp, Func<double, double> methodToParse)
+        private static string Parser(string temp, Func<double, double> methodToParse, int fractionalCount)
         {
             var convertedTemp = string.Empty;
             if (double.TryParse(temp, out var inputAsDouble))
             {
-                convertedTemp = methodToParse(inputAsDouble).ToString(CultureInfo.InvariantCulture);
+                convertedTemp = Rounder(methodToParse(inputAsDouble), fractionalCount).ToString(CultureInfo.InvariantCulture);
             }
 
             return convertedTemp;
+        }
+
+        private static double Rounder(double input, int fractionalCount = -1)
+        {
+            return fractionalCount < 0 ? input : Math.Round(input, fractionalCount);
         }
     }
 }


### PR DESCRIPTION
Add additional `fractionalCount` parameter to extensions.
The `fractionalCount` parameter has a default of "-1" to ignore any limiting.
`Math.Round()` will throw an exception if the limiter is greater than 15.